### PR TITLE
feature: Create Tenant-5

### DIFF
--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -21,11 +21,18 @@ jacocoTestReport {
             fileTree(dir: it, exclude: [
                     /*excluding original osis stub code*/
                     "**/com/vmware/osis/resource/*.*",
-                    "**/com/vmware/osis/model/*.*",
+                    "**/com/vmware/osis/model/**/*.*",
                     "**/com/vmware/osis/annotation/*.*",
-                    "**/com/vmware/osis/security/*.*",
+                    "**/com/vmware/osis/security/**/*.*",
                     "**/com/vmware/osis/service/*.*",
-                    "**/com/vmware/osis/validation/*.*"
+                    "**/com/vmware/osis/validation/*.*",
+                    "**/com/vmware/osis/platform/**/*.*",
+                    "**/com/vmware/osis/platform/*.*",
+
+                    /*Ignore config classes*/
+                    "**/com/scality/osis/configuration/*.*",
+                    "**/com/scality/osis/*.*",
+                    "**/com/scality/osis/security/**/*.*"
             ])
         }))
     }
@@ -38,11 +45,18 @@ jacocoTestCoverageVerification {
             fileTree(dir: it, exclude: [
                     /*excluding original osis stub code*/
                     "**/com/vmware/osis/resource/*.*",
-                    "**/com/vmware/osis/model/*.*",
+                    "**/com/vmware/osis/model/**/*.*",
                     "**/com/vmware/osis/annotation/*.*",
-                    "**/com/vmware/osis/security/*.*",
+                    "**/com/vmware/osis/security/**/*.*",
                     "**/com/vmware/osis/service/*.*",
-                    "**/com/vmware/osis/validation/*.*"
+                    "**/com/vmware/osis/validation/*.*",
+                    "**/com/vmware/osis/platform/**/*.*",
+                    "**/com/vmware/osis/platform/*.*",
+
+                    /*Ignore config classes*/
+                    "**/com/scality/osis/configuration/*.*",
+                    "**/com/scality/osis/*.*",
+                    "**/com/scality/osis/security/**/*.*"
             ])
         }))
     }

--- a/osis-core/src/main/java/com/scality/osis/configuration/ScalityRestConfig.java
+++ b/osis-core/src/main/java/com/scality/osis/configuration/ScalityRestConfig.java
@@ -1,4 +1,5 @@
 /**
+ *Copyright 2020 VMware, Inc.
  *Copyright 2021 Scality, Inc.
  *SPDX-License-Identifier: Apache License 2.0
  */
@@ -6,9 +7,41 @@
 package com.scality.osis.configuration;
 
 
+import com.scality.osis.vaultadmin.VaultAdmin;
+import com.scality.osis.vaultadmin.VaultAdminBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 
 @Configuration
 public class ScalityRestConfig {
-    // Scality client and dependencies
+
+
+    @Value("${osis.scality.vault.access-key}")
+    private String vaultAccessKey;
+
+    @Value("${osis.scality.vault.secret-key}")
+    private String vaultSecretKey;
+
+    @Value("${osis.scality.vault.endpoint}")
+    private String vaultEndpoint;
+
+    @Bean
+    public ClientHttpRequestFactory simpleClientHttpRequestFactory() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setReadTimeout(10000);
+        factory.setConnectTimeout(10000);
+        return factory;
+    }
+
+    @Bean
+    public VaultAdmin getVaultAdmin() {
+        return new VaultAdminBuilder()
+                .setAccessKey(vaultAccessKey)
+                .setSecretKey(vaultSecretKey)
+                .setEndpoint(vaultEndpoint)
+                .build();
+    }
 }

--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisService.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisService.java
@@ -6,6 +6,11 @@
 
 package com.scality.osis.service.impl;
 
+import com.google.gson.Gson;
+import com.scality.osis.utils.ScalityModelConverter;
+import com.scality.osis.vaultadmin.VaultAdmin;
+import com.scality.vaultclient.dto.CreateAccountRequestDTO;
+import com.scality.vaultclient.dto.CreateAccountResponseDTO;
 import com.vmware.osis.platform.AppEnv;
 import com.vmware.osis.model.*;
 import com.vmware.osis.model.exception.NotImplementedException;
@@ -30,12 +35,39 @@ public class ScalityOsisService implements OsisService {
     private AppEnv appEnv;
 
     @Autowired
+    private VaultAdmin vaultAdmin;
+
+    @Autowired
     private OsisCapsManager osisCapsManager;
 
+    public ScalityOsisService(){}
 
+    public ScalityOsisService(VaultAdmin vaultAdmin){
+        this.vaultAdmin = vaultAdmin;
+    }
+
+    /**
+     * Create a tenant in the platform
+     *
+     * @param osisTenant Tenant to create in the platform (required)
+     * @return A tenant is created
+     */
     @Override
     public OsisTenant createTenant(OsisTenant osisTenant) {
-        throw new NotImplementedException();
+        logger.info("Create Tenant request received:{}", new Gson().toJson(osisTenant));
+        CreateAccountRequestDTO accountRequest = ScalityModelConverter.toScalityAccountRequest(osisTenant);
+
+        logger.debug("[Vault]CreateAccount request:{}", new Gson().toJson(accountRequest));
+
+        CreateAccountResponseDTO accountResponse = vaultAdmin.createAccount(accountRequest);
+
+        logger.debug("[Vault]CreateAccount response:{}", new Gson().toJson(accountResponse));
+
+        OsisTenant resOsisTenant = ScalityModelConverter.toOsisTenant(accountResponse);
+
+        logger.info("Create Tenant response:{}", new Gson().toJson(resOsisTenant));
+
+        return resOsisTenant;
     }
 
     @Override

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.utils;
+
+public final class ScalityConstants {
+
+    private ScalityConstants() {
+    }
+
+    public static final String TENANT_EMAIL_SUFFIX = "@osis.scality.com";
+
+    public static final String CD_TENANT_ID_PREFIX = "cd_tenant_id%3D%3D";
+
+    public static final String SEPARATOR = ".";
+}

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -5,12 +5,111 @@
 
 package com.scality.osis.utils;
 
+import com.vmware.osis.model.OsisTenant;
+import com.vmware.osis.model.exception.BadRequestException;
+import com.scality.vaultclient.dto.AccountData;
+import com.scality.vaultclient.dto.CreateAccountRequestDTO;
+import com.scality.vaultclient.dto.CreateAccountResponseDTO;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.scality.osis.utils.ScalityConstants.*;
+
 /**
  * Convert between OSIS and Scality models
  */
 public final class ScalityModelConverter {
 
+
     private ScalityModelConverter() {
     }
 
+    /* All Converter methods below converts OSIS model objects to Vault/Scality request formats */
+
+    /**
+     * Converts OSIS Tenant object to Vault Create Account request
+     * @param osisTenant the osis tenant
+     *
+     * @return the create account request dto
+     */
+    public static CreateAccountRequestDTO toScalityAccountRequest(OsisTenant osisTenant) {
+        if(!osisTenant.getActive()){
+//            Scality does not support inactive tenant creation
+            throw new BadRequestException("Creating inactive tenant is not supported");
+        }
+        CreateAccountRequestDTO createAccountRequestDTO = new CreateAccountRequestDTO();
+
+        if (!StringUtils.isEmpty(osisTenant.getTenantId())) {
+            createAccountRequestDTO.setExternalAccountId(osisTenant.getTenantId());
+        }
+        createAccountRequestDTO.setName(osisTenant.getName());
+
+        createAccountRequestDTO.setEmailAddress(generateTenantEmail(osisTenant.getName()));
+
+        createAccountRequestDTO.setCustomAttributes(toScalityCustomAttributes(osisTenant.getCdTenantIds()));
+
+        return createAccountRequestDTO;
+    }
+
+    /**
+     * Generates tenant email string using tenant name.
+     *  example email address: tenant.name@osis.scality.com
+     *
+     * @param name the name
+     * @return the string
+     */
+    public static String generateTenantEmail(String name) {
+        return name.replaceAll(" ", SEPARATOR) + TENANT_EMAIL_SUFFIX;
+    }
+
+    /**
+     * Converts OSIS cdTenantIDs list to Vault Account customAttributes Map Format
+     *
+     * @param cdTenantIds the cd tenant ids list. Example:<code>["9b7e3259-aace-414c-bfd8-94daa0efefaf","7b7e3259-aace-414c-bfd8-94daa0efefaf"]</code>
+     * @return the customAttributes map.
+     *          Example: <code>{("cd_tenant_id%3D%3D9b7e3259-aace-414c-bfd8-94daa0efefaf", ""),
+     *                          ("cd_tenant_id%3D%3D7b7e3259-aace-414c-bfd8-94daa0efefaf", "")}</code>
+     */
+    public static Map<String,String> toScalityCustomAttributes(List<String> cdTenantIds) {
+        return cdTenantIds.stream()
+                .collect(Collectors.toMap(str-> CD_TENANT_ID_PREFIX + str, str -> ""));
+    }
+
+    /* Converter methods below will convert Vault/Scality responses to OSIS model objects @param accountResponse the account response */
+
+
+    /**
+     * Converts Vault Create Account response to OSIS Tenant object
+     *
+     * @return the osis tenant
+     */
+    public static OsisTenant toOsisTenant(CreateAccountResponseDTO accountResponse) {
+        AccountData account = accountResponse.getAccount().getData();
+        return new OsisTenant()
+                .name(account.getName())
+                .active(true)
+                .cdTenantIds(toOsisCDTenantIds(account.getCustomAttributes()))
+                .tenantId(account.getId());
+    }
+
+    /**
+     * Converts Vault Account customAttributes Map Format to OSIS cdTenantIDs list.
+     *
+     * @param customAttributes the customAttributes map.
+     *      *          Example: <code>{("cd_tenant_id%3D%3D9b7e3259-aace-414c-bfd8-94daa0efefaf", ""),
+     *      *                          ("cd_tenant_id%3D%3D7b7e3259-aace-414c-bfd8-94daa0efefaf", "")}</code>
+     * @return the cd tenant ids list. Example:<code>["9b7e3259-aace-414c-bfd8-94daa0efefaf","7b7e3259-aace-414c-bfd8-94daa0efefaf"]</code>
+     */
+    public static List<String> toOsisCDTenantIds(Map<String,String> customAttributes) {
+        if(customAttributes.size() == 0)
+            return new ArrayList<>();
+
+        List<String> cdTenantIds = new ArrayList<String>(customAttributes.keySet()).stream().collect(Collectors.toList());
+        cdTenantIds.replaceAll(x -> StringUtils.removeStart(x, CD_TENANT_ID_PREFIX));
+        return cdTenantIds;
+    }
 }

--- a/osis-core/src/test/java/com/scality/osis/ScalityAppEnvTest.java
+++ b/osis-core/src/test/java/com/scality/osis/ScalityAppEnvTest.java
@@ -1,0 +1,386 @@
+package com.scality.osis;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.core.env.Environment;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class ScalityAppEnvTest {
+    private static final String TEST_RESULT= "result";
+    private static final String TEST_RESULT_NULL_ERR= "result should be null";
+
+    @Mock
+    private Environment mockEnv;
+
+    @InjectMocks
+    private ScalityAppEnv appEnvUnderTest;
+
+    @BeforeEach
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void testGetVaultEndpoint() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.vault.endpoint")).thenReturn(TEST_RESULT);
+
+        // Run the test
+        final String result = appEnvUnderTest.getPlatformEndpoint();
+
+        // Verify the results
+        assertEquals(result, TEST_RESULT, "testGetVaultEndpoint should be equal");
+    }
+
+    @Test
+    public void testGetVaultEndpoint_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.vault.endpoint")).thenReturn(null);
+
+        // Run the test
+        final String result = appEnvUnderTest.getPlatformEndpoint();
+
+        // Verify the results
+        assertNull(result, TEST_RESULT_NULL_ERR);
+    }
+
+    @Test
+    public void testGetVaultAccessKey() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.vault.access-key")).thenReturn(TEST_RESULT);
+
+        // Run the test
+        final String result = appEnvUnderTest.getPlatformAccessKey();
+
+        // Verify the results
+        assertEquals(result, TEST_RESULT,"testGetVaultAccessKey failed");
+    }
+
+    @Test
+    public void testGetVaultAccessKey_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.vault.access-key")).thenReturn(null);
+
+        // Run the test
+        final String result = appEnvUnderTest.getPlatformAccessKey();
+
+        // Verify the results
+        assertNull(result, TEST_RESULT_NULL_ERR);
+    }
+
+    @Test
+    public void testGetVaultSecretKey() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.vault.secret-key")).thenReturn(TEST_RESULT);
+
+        // Run the test
+        final String result = appEnvUnderTest.getPlatformSecretKey();
+
+        // Verify the results
+        assertEquals(result, TEST_RESULT, "testGetVaultSecretKey failed");
+    }
+
+    @Test
+    public void testGetVaultSecretKey_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.vault.secret-key")).thenReturn(null);
+
+        // Run the test
+        final String result = appEnvUnderTest.getPlatformSecretKey();
+
+        // Verify the results
+        assertNull(result, TEST_RESULT_NULL_ERR);
+    }
+
+    @Test
+    public void testGetS3Endpoint() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.s3.endpoint")).thenReturn(TEST_RESULT);
+
+        // Run the test
+        final String result = appEnvUnderTest.getS3Endpoint();
+
+        // Verify the results
+        assertEquals(result, TEST_RESULT, "testGetS3Endpoint failed");
+    }
+
+    @Test
+    public void testGetS3Endpoint_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.s3.endpoint")).thenReturn(null);
+
+        // Run the test
+        final String result = appEnvUnderTest.getS3Endpoint();
+
+        // Verify the results
+        assertNull(result, TEST_RESULT_NULL_ERR);
+    }
+
+    @Test
+    public void testGetConsoleEndpoint() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.console.endpoint")).thenReturn(TEST_RESULT);
+
+        // Run the test
+        final String result = appEnvUnderTest.getConsoleEndpoint();
+
+        // Verify the results
+        assertEquals(result, TEST_RESULT, "testGetConsoleEndpoint failed");
+    }
+
+    @Test
+    public void testGetConsoleEndpoint_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.console.endpoint")).thenReturn(null);
+
+        // Run the test
+        final String result = appEnvUnderTest.getConsoleEndpoint();
+
+        // Verify the results
+        assertNull(result, TEST_RESULT_NULL_ERR);
+    }
+
+    @Test
+    public void testGetStorageInfo() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.storage-classes")).thenReturn(TEST_RESULT);
+
+        // Run the test
+        final List<String> result = appEnvUnderTest.getStorageInfo();
+
+        // Verify the results
+        assertEquals(result, Arrays.asList(TEST_RESULT), "testGetStorageInfo failed");
+    }
+
+    @Test
+    public void testGetStorageInfo_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.storage-classes")).thenReturn(null);
+
+        // Run the test
+        final List<String> result = appEnvUnderTest.getStorageInfo();
+
+        // Verify the results
+        assertEquals(result, Arrays.asList("standard"), "testGetStorageInfo_EnvironmentReturnsNull failed");
+    }
+
+    @Test
+    public void testGetRegionInfo() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.region")).thenReturn("region1,region2");
+
+        // Run the test
+        final List<String> result = appEnvUnderTest.getRegionInfo();
+
+        // Verify the results
+        assertEquals(result, Arrays.asList("region1","region2"), "testGetRegionInfo failed");
+    }
+
+    @Test
+    public void testGetRegionInfo_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.region")).thenReturn(null);
+
+        // Run the test
+        final List<String> result = appEnvUnderTest.getRegionInfo();
+
+        // Verify the results
+        assertEquals(result, Arrays.asList("default"), "testGetRegionInfo_EnvironmentReturnsNull failed");
+    }
+
+    @Test
+    public void testGetPlatformName() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.name")).thenReturn("scality");
+
+        // Run the test
+        final String result = appEnvUnderTest.getPlatformName();
+
+        // Verify the results
+        assertEquals(result, "scality", "testGetPlatformName failed");
+    }
+
+    @Test
+    public void testGetPlatformName_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.name")).thenReturn(null);
+
+        // Run the test
+        final String result = appEnvUnderTest.getPlatformName();
+
+        // Verify the results
+        assertNull(result, TEST_RESULT_NULL_ERR);
+    }
+
+    @Test
+    public void testGetPlatformVersion() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.version")).thenReturn("v1");
+
+        // Run the test
+        final String result = appEnvUnderTest.getPlatformVersion();
+
+        // Verify the results
+        assertEquals(result, "v1", "testGetPlatformVersion failed");
+    }
+
+    @Test
+    public void testGetPlatformVersion_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.version")).thenReturn(null);
+
+        // Run the test
+        final String result = appEnvUnderTest.getPlatformVersion();
+
+        // Verify the results
+        assertNull(result, TEST_RESULT_NULL_ERR);
+    }
+
+    @Test
+    public void testGetApiVersion() {
+        // Setup
+        when(mockEnv.getProperty("osis.api.version")).thenReturn("v1");
+
+        // Run the test
+        final String result = appEnvUnderTest.getApiVersion();
+
+        // Verify the results
+        assertEquals(result, "v1", "testGetApiVersion failed");
+    }
+
+    @Test
+    public void testGetApiVersion_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("osis.api.version")).thenReturn(null);
+
+        // Run the test
+        final String result = appEnvUnderTest.getApiVersion();
+
+        // Verify the results
+        assertNull(result, TEST_RESULT_NULL_ERR);
+    }
+
+    @Test
+    public void testIsApiTokenEnabled() {
+        // Setup
+        when(mockEnv.getProperty("security.jwt.enabled")).thenReturn("true");
+
+        // Run the test
+        final boolean result = appEnvUnderTest.isApiTokenEnabled();
+
+        // Verify the results
+        assertTrue(result, "testIsApiTokenEnabled failed");
+    }
+
+    @Test
+    public void testIsApiTokenEnabled_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("security.jwt.enabled")).thenReturn(null);
+
+        // Run the test
+        final boolean result = appEnvUnderTest.isApiTokenEnabled();
+
+        // Verify the results
+        assertFalse(result, "testIsApiTokenEnabled_EnvironmentReturnsNull failed");
+    }
+
+    @Test
+    public void testGetTokenIssuer() {
+        // Setup
+        when(mockEnv.getProperty("security.jwt.token-issuer")).thenReturn(TEST_RESULT);
+
+        // Run the test
+        final String result = appEnvUnderTest.getTokenIssuer();
+
+        // Verify the results
+        assertEquals(result, TEST_RESULT, "testGetTokenIssuer failed");
+    }
+
+    @Test
+    public void testGetTokenIssuer_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("security.jwt.token-issuer")).thenReturn(null);
+
+        // Run the test
+        final String result = appEnvUnderTest.getTokenIssuer();
+
+        // Verify the results
+        assertNull(result, TEST_RESULT_NULL_ERR);
+    }
+
+    @Test
+    public void testGetAccessTokenExpirationTime() {
+        // Setup
+        when(mockEnv.getProperty("security.jwt.access-token-expiration-time")).thenReturn("1000");
+
+        // Run the test
+        final int result = appEnvUnderTest.getAccessTokenExpirationTime();
+
+        // Verify the results
+        assertEquals(result, 1000, "testGetAccessTokenExpirationTime failed");
+    }
+
+    @Test
+    public void testGetAccessTokenExpirationTime_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("security.jwt.access-token-expiration-time")).thenReturn(null);
+
+        // Run the test
+        // Verify the results
+        assertThrows(NumberFormatException.class, ()->appEnvUnderTest.getAccessTokenExpirationTime(), "testGetAccessTokenExpirationTime_EnvironmentReturnsNull should throw NumberFormatException");
+    }
+
+    @Test
+    public void testGetTokenSigningKey() {
+        // Setup
+        when(mockEnv.getProperty("security.jwt.token-signing-key")).thenReturn(TEST_RESULT);
+
+        // Run the test
+        final String result = appEnvUnderTest.getTokenSigningKey();
+
+        // Verify the results
+        assertEquals(result, TEST_RESULT, "testGetTokenSigningKey failed");
+    }
+
+    @Test
+    public void testGetTokenSigningKey_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("security.jwt.token-signing-key")).thenReturn(null);
+
+        // Run the test
+        final String result = appEnvUnderTest.getTokenSigningKey();
+
+        // Verify the results
+        assertNull(result, TEST_RESULT_NULL_ERR);
+    }
+
+    @Test
+    public void testGetRefreshTokenExpirationTime() {
+        // Setup
+        when(mockEnv.getProperty("security.jwt.refresh_token_expiration_time")).thenReturn("1000");
+
+        // Run the test
+        final int result = appEnvUnderTest.getRefreshTokenExpirationTime();
+
+        // Verify the results
+        assertEquals(result, 1000, "testGetRefreshTokenExpirationTime failed");
+    }
+
+    @Test
+    public void testGetRefreshTokenExpirationTime_EnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("security.jwt.refresh_token_expiration_time")).thenReturn(null);
+
+        // Run the test
+        // Verify the results
+        assertThrows(NumberFormatException.class, ()->appEnvUnderTest.getRefreshTokenExpirationTime(), "testGetRefreshTokenExpirationTime_EnvironmentReturnsNull should throw NumberFormatException");
+    }
+}

--- a/osis-core/src/test/java/com/scality/osis/configuration/ScalityRestConfigTest.java
+++ b/osis-core/src/test/java/com/scality/osis/configuration/ScalityRestConfigTest.java
@@ -1,0 +1,45 @@
+package com.scality.osis.configuration;
+
+import com.scality.osis.vaultadmin.VaultAdmin;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ScalityRestConfigTest {
+
+    private ScalityRestConfig scalityRestConfigUnderTest;
+
+    @BeforeEach
+    public void setUp() {
+        scalityRestConfigUnderTest = new ScalityRestConfig();
+    }
+
+    @Test
+    public void testSimpleClientHttpRequestFactory() {
+        // Setup
+
+        // Run the test
+        final ClientHttpRequestFactory result = scalityRestConfigUnderTest.simpleClientHttpRequestFactory();
+
+        // Verify the results
+        assertNotNull(result,"result should not be null");
+    }
+
+    @Test
+    public void testGetVaultAdmin() {
+        // Setup private fields in the object with test values
+        ReflectionTestUtils.setField(scalityRestConfigUnderTest, "vaultAccessKey", "accesskey");
+        ReflectionTestUtils.setField(scalityRestConfigUnderTest, "vaultSecretKey", "secretkey");
+        ReflectionTestUtils.setField(scalityRestConfigUnderTest, "vaultEndpoint", "http://127.0.0.1");
+        // Run the test
+        final VaultAdmin result = scalityRestConfigUnderTest.getVaultAdmin();
+
+        // Verify the results
+        assertNotNull(result,"result should not be null");
+
+
+    }
+}

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTest.java
@@ -1,0 +1,508 @@
+package com.scality.osis.service.impl;
+
+import com.scality.osis.utils.ScalityTestUtils;
+import com.vmware.osis.model.OsisCaps;
+import com.vmware.osis.model.OsisTenant;
+import com.vmware.osis.model.OsisUser;
+import com.vmware.osis.model.PageInfo;
+import com.vmware.osis.model.PageOfTenants;
+import com.vmware.osis.model.exception.BadRequestException;
+import com.vmware.osis.model.exception.NotImplementedException;
+import com.scality.vaultclient.dto.Account;
+import com.scality.vaultclient.dto.AccountData;
+import com.scality.vaultclient.dto.CreateAccountRequestDTO;
+import com.scality.vaultclient.dto.CreateAccountResponseDTO;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+import com.scality.osis.vaultadmin.impl.VaultAdminImpl;
+import com.scality.osis.vaultadmin.impl.VaultServiceException;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.scality.osis.utils.ScalityTestUtils.SAMPLE_CD_TENANT_IDS;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class ScalityOsisServiceTest {
+    private static final String TEST_TENANT_ID ="tenantId";
+    private static final String TEST_STR ="value";
+    private static final String NOT_IMPLEMENTED_EXCEPTION_ERR ="expected NotImplementedException";
+    private static final String TEST_USER_ID ="userId";
+    private static final String TEST_NAME ="name";
+
+    //vault admin mock object
+    private static VaultAdminImpl vaultAdminMock;
+
+    private static ScalityOsisService scalityOsisServiceUnderTest;
+
+    @BeforeAll
+    private static void init(){
+        vaultAdminMock = mock(VaultAdminImpl.class);
+        scalityOsisServiceUnderTest = new ScalityOsisService(vaultAdminMock);
+        initMocks();
+    }
+
+    private static void initMocks() {
+        //initialize mock create account response
+        when(vaultAdminMock.createAccount(any(CreateAccountRequestDTO.class)))
+                .thenAnswer((Answer<CreateAccountResponseDTO>) invocation -> {
+                    CreateAccountRequestDTO request = invocation.getArgument(0);
+                    AccountData data = new AccountData();
+                    data.setEmailAddress(request.getEmailAddress());
+                    data.setName(request.getName());
+                    if(StringUtils.isEmpty(request.getExternalAccountId())){
+                        data.setId(ScalityTestUtils.SAMPLE_TENANT_ID);
+                    } else{
+                        data.setId(request.getExternalAccountId());
+                    }
+                    data.setCustomAttributes(request.getCustomAttributes());
+                    Account account = new Account();
+                    account.setData(data);
+                    CreateAccountResponseDTO response = new CreateAccountResponseDTO();
+                    response.setAccount(account);
+
+                    return response;
+                });
+    }
+
+    @Test
+    public void testCreateTenant(){
+
+        // Call Scality Osis service to create a tenant
+        OsisTenant osisTenantRes = scalityOsisServiceUnderTest.createTenant(ScalityTestUtils.createSampleOsisTenantObj());
+
+        assertEquals(ScalityTestUtils.SAMPLE_ID, osisTenantRes.getTenantId());
+        assertEquals(ScalityTestUtils.SAMPLE_TENANT_NAME, osisTenantRes.getName());
+        assertTrue(SAMPLE_CD_TENANT_IDS.size() == osisTenantRes.getCdTenantIds().size() &&
+                SAMPLE_CD_TENANT_IDS.containsAll(osisTenantRes.getCdTenantIds()) && osisTenantRes.getCdTenantIds().containsAll(SAMPLE_CD_TENANT_IDS));
+        assertTrue(osisTenantRes.getActive());
+    }
+
+    @Test
+    public void testCreateTenantInactive(){
+        OsisTenant osisTenantReq = ScalityTestUtils.createSampleOsisTenantObj();
+        osisTenantReq.active(false);
+
+        // Call Scality Osis service to create a tenant
+        assertThrows(BadRequestException.class, () -> {
+            scalityOsisServiceUnderTest.createTenant(osisTenantReq);
+        });
+    }
+
+    @Test
+    public void testCreateTenant500(){
+
+        when(vaultAdminMock.createAccount(any(CreateAccountRequestDTO.class)))
+                .thenAnswer((Answer<CreateAccountResponseDTO>) invocation -> {
+                    throw new VaultServiceException(500, "EntityAlreadyExists");
+                });
+
+        assertThrows(VaultServiceException.class, () -> {
+            scalityOsisServiceUnderTest.createTenant(ScalityTestUtils.createSampleOsisTenantObj());
+        });
+
+        //resetting mocks to original
+        init();
+    }
+
+    @Test
+    public void testCreateTenant400(){
+
+        when(vaultAdminMock.createAccount(any(CreateAccountRequestDTO.class)))
+                .thenAnswer((Answer<CreateAccountResponseDTO>) invocation -> {
+                    throw new VaultServiceException(400, "Bad Request");
+                });
+
+        assertThrows(VaultServiceException.class, () -> {
+            scalityOsisServiceUnderTest.createTenant(ScalityTestUtils.createSampleOsisTenantObj());
+        });
+
+        //resetting mocks to original
+        initMocks();
+    }
+
+    @Test
+    public void testQueryTenants() {
+        // Setup
+        final PageOfTenants expectedResult = new PageOfTenants();
+        final OsisTenant osisTenant = new OsisTenant();
+        osisTenant.active(false);
+        osisTenant.name(TEST_NAME);
+        osisTenant.setName(TEST_NAME);
+        osisTenant.tenantId(TEST_TENANT_ID);
+        osisTenant.setTenantId(TEST_TENANT_ID);
+        osisTenant.cdTenantIds(Arrays.asList(TEST_STR));
+        osisTenant.setCdTenantIds(Arrays.asList(TEST_STR));
+        expectedResult.items(Arrays.asList(osisTenant));
+        final OsisTenant osisTenant1 = new OsisTenant();
+        osisTenant1.active(false);
+        osisTenant1.name(TEST_NAME);
+        osisTenant1.setName(TEST_NAME);
+        osisTenant1.tenantId(TEST_TENANT_ID);
+        osisTenant1.setTenantId(TEST_TENANT_ID);
+        osisTenant1.cdTenantIds(Arrays.asList(TEST_STR));
+        osisTenant1.setCdTenantIds(Arrays.asList(TEST_STR));
+        expectedResult.setItems(Arrays.asList(osisTenant1));
+        final PageInfo pageInfo = new PageInfo();
+        pageInfo.limit(0L);
+        pageInfo.setLimit(0L);
+        pageInfo.offset(0L);
+        pageInfo.setOffset(0L);
+        pageInfo.total(0L);
+        pageInfo.setTotal(0L);
+        expectedResult.pageInfo(pageInfo);
+        final PageInfo pageInfo1 = new PageInfo();
+        pageInfo1.limit(0L);
+        pageInfo1.setLimit(0L);
+        pageInfo1.offset(0L);
+        pageInfo1.setOffset(0L);
+        pageInfo1.total(0L);
+        pageInfo1.setTotal(0L);
+        expectedResult.setPageInfo(pageInfo1);
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.queryTenants(0L, 0L, "filter"), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testListTenants() {
+        // Setup
+        final PageOfTenants expectedResult = new PageOfTenants();
+        final OsisTenant osisTenant = new OsisTenant();
+        osisTenant.active(false);
+        osisTenant.name(TEST_NAME);
+        osisTenant.setName(TEST_NAME);
+        osisTenant.tenantId(TEST_TENANT_ID);
+        osisTenant.setTenantId(TEST_TENANT_ID);
+        osisTenant.cdTenantIds(Arrays.asList(TEST_STR));
+        osisTenant.setCdTenantIds(Arrays.asList(TEST_STR));
+        expectedResult.items(Arrays.asList(osisTenant));
+        final OsisTenant osisTenant1 = new OsisTenant();
+        osisTenant1.active(false);
+        osisTenant1.name(TEST_NAME);
+        osisTenant1.setName(TEST_NAME);
+        osisTenant1.tenantId(TEST_TENANT_ID);
+        osisTenant1.setTenantId(TEST_TENANT_ID);
+        osisTenant1.cdTenantIds(Arrays.asList(TEST_STR));
+        osisTenant1.setCdTenantIds(Arrays.asList(TEST_STR));
+        expectedResult.setItems(Arrays.asList(osisTenant1));
+        final PageInfo pageInfo = new PageInfo();
+        pageInfo.limit(0L);
+        pageInfo.setLimit(0L);
+        pageInfo.offset(0L);
+        pageInfo.setOffset(0L);
+        pageInfo.total(0L);
+        pageInfo.setTotal(0L);
+        expectedResult.pageInfo(pageInfo);
+        final PageInfo pageInfo1 = new PageInfo();
+        pageInfo1.limit(0L);
+        pageInfo1.setLimit(0L);
+        pageInfo1.offset(0L);
+        pageInfo1.setOffset(0L);
+        pageInfo1.total(0L);
+        pageInfo1.setTotal(0L);
+        expectedResult.setPageInfo(pageInfo1);
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.listTenants(0L, 0L), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testCreateUser() {
+        // Setup
+        final OsisUser osisUser = new OsisUser();
+        osisUser.userId(TEST_USER_ID);
+        osisUser.setUserId(TEST_USER_ID);
+        osisUser.canonicalUserId("canonicalUserId");
+        osisUser.setCanonicalUserId("canonicalUserId");
+        osisUser.tenantId(TEST_TENANT_ID);
+        osisUser.setTenantId(TEST_TENANT_ID);
+        osisUser.active(false);
+        osisUser.setActive(false);
+        osisUser.cdUserId("cdUserId");
+        osisUser.setCdUserId("cdUserId");
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.createUser(osisUser), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testQueryUsers() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.queryUsers(0L, 0L, "filter"), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testCreateS3Credential() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.createS3Credential(TEST_TENANT_ID, TEST_USER_ID), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testQueryS3Credentials() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.queryS3Credentials(0L, 0L, "filter"), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testGetProviderConsoleUrl() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getProviderConsoleUrl(), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testGetTenantConsoleUrl() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getTenantConsoleUrl(TEST_TENANT_ID), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testGetS3Capabilities() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getS3Capabilities(), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testDeleteS3Credential() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.deleteS3Credential(TEST_TENANT_ID, TEST_USER_ID, "accessKey"), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testDeleteTenant() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.deleteTenant(TEST_TENANT_ID, false), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testUpdateTenant() {
+        // Setup
+        final OsisTenant osisTenant = new OsisTenant();
+        osisTenant.active(false);
+        osisTenant.name(TEST_NAME);
+        osisTenant.setName(TEST_NAME);
+        osisTenant.tenantId(TEST_TENANT_ID);
+        osisTenant.setTenantId(TEST_TENANT_ID);
+        osisTenant.cdTenantIds(Arrays.asList(TEST_STR));
+        osisTenant.setCdTenantIds(Arrays.asList(TEST_STR));
+
+        final OsisTenant expectedResult = new OsisTenant();
+        expectedResult.active(false);
+        expectedResult.name(TEST_NAME);
+        expectedResult.setName(TEST_NAME);
+        expectedResult.tenantId(TEST_TENANT_ID);
+        expectedResult.setTenantId(TEST_TENANT_ID);
+        expectedResult.cdTenantIds(Arrays.asList(TEST_STR));
+        expectedResult.setCdTenantIds(Arrays.asList(TEST_STR));
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.updateTenant(TEST_TENANT_ID, osisTenant), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testDeleteUser() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.deleteUser(TEST_TENANT_ID, TEST_USER_ID, false), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testGetS3Credential() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getS3Credential("accessKey"), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testGetTenant() {
+        // Setup
+        final OsisTenant expectedResult = new OsisTenant();
+        expectedResult.active(false);
+        expectedResult.name(TEST_NAME);
+        expectedResult.setName(TEST_NAME);
+        expectedResult.tenantId(TEST_TENANT_ID);
+        expectedResult.setTenantId(TEST_TENANT_ID);
+        expectedResult.cdTenantIds(Arrays.asList(TEST_STR));
+        expectedResult.setCdTenantIds(Arrays.asList(TEST_STR));
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getTenant(TEST_TENANT_ID), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testGetUser1() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getUser("canonicalUserId"), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testGetUser2() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getUser(TEST_TENANT_ID, TEST_USER_ID), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testHeadTenant() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.headTenant(TEST_TENANT_ID), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testHeadUser() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.headUser(TEST_TENANT_ID, TEST_USER_ID), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+
+    }
+
+    @Test
+    public void testListS3Credentials() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.listS3Credentials(TEST_TENANT_ID, TEST_USER_ID, 0L, 0L), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testListUsers() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.listUsers(TEST_TENANT_ID, 0L, 0L), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testUpdateUser() {
+        // Setup
+        final OsisUser osisUser = new OsisUser();
+        osisUser.userId(TEST_USER_ID);
+        osisUser.setUserId(TEST_USER_ID);
+        osisUser.canonicalUserId("canonicalUserId");
+        osisUser.setCanonicalUserId("canonicalUserId");
+        osisUser.tenantId(TEST_TENANT_ID);
+        osisUser.setTenantId(TEST_TENANT_ID);
+        osisUser.active(false);
+        osisUser.setActive(false);
+        osisUser.cdUserId("cdUserId");
+        osisUser.setCdUserId("cdUserId");
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.updateUser(TEST_TENANT_ID, TEST_USER_ID, osisUser), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testGetInformation() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getInformation("domain"), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testUpdateOsisCaps() {
+        // Setup
+        final OsisCaps osisCaps = new OsisCaps();
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.updateOsisCaps(osisCaps), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testGetBucketList() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getBucketList(TEST_TENANT_ID, 0L, 0L), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+    }
+
+    @Test
+    public void testGetOsisUsage() {
+        // Setup
+
+        // Run the test
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getOsisUsage(Optional.of(TEST_STR), Optional.of(TEST_STR)), NOT_IMPLEMENTED_EXCEPTION_ERR);
+
+        // Verify the results
+
+    }
+
+
+}

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
@@ -1,0 +1,94 @@
+package com.scality.osis.utils;
+
+import com.vmware.osis.model.OsisTenant;
+import com.vmware.osis.model.exception.BadRequestException;
+import com.scality.vaultclient.dto.Account;
+import com.scality.vaultclient.dto.AccountData;
+import com.scality.vaultclient.dto.CreateAccountRequestDTO;
+import com.scality.vaultclient.dto.CreateAccountResponseDTO;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.scality.osis.utils.ScalityTestUtils.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+public class ScalityModelConverterTest {
+
+    @Test
+    public void toScalityAccountEmailTest(){
+        assertEquals(SAMPLE_SCALITY_ACCOUNT_EMAIL,
+                ScalityModelConverter.generateTenantEmail(SAMPLE_TENANT_NAME),"failed generateTenantEmail");
+    }
+
+    @Test
+    public void toOsisCDTenantIdsTest(){
+        List<String> result = ScalityModelConverter.toOsisCDTenantIds(SAMPLE_CUSTOM_ATTRIBUTES);
+        assertTrue(SAMPLE_CD_TENANT_IDS.size() == result.size() &&
+                SAMPLE_CD_TENANT_IDS.containsAll(result) && result.containsAll(SAMPLE_CD_TENANT_IDS), "failed toOsisCDTenantIdsTest");
+    }
+
+    @Test
+    public void toScalityAccountRequestTest() throws Exception {
+
+        OsisTenant osisTenant = new OsisTenant();
+        osisTenant.tenantId(SAMPLE_TENANT_ID);
+        osisTenant.name(SAMPLE_TENANT_NAME);
+        osisTenant.cdTenantIds(SAMPLE_CD_TENANT_IDS);
+        osisTenant.active(true);
+
+        CreateAccountRequestDTO createAccountRequestDTO = ScalityModelConverter.toScalityAccountRequest(osisTenant);
+
+        assertEquals(SAMPLE_SCALITY_ACCOUNT_EMAIL, createAccountRequestDTO.getEmailAddress(), "failed toScalityAccountRequestTest:getEmailAddress()");
+        assertEquals(SAMPLE_TENANT_NAME, createAccountRequestDTO.getName(), "failed toScalityAccountRequestTest:getName()");
+        assertEquals(SAMPLE_TENANT_ID, createAccountRequestDTO.getExternalAccountId(), "failed toScalityAccountRequestTest:getExternalAccountId()");
+    }
+
+    @Test
+    public void toScalityAccountRequestNullTenantId() {
+
+        OsisTenant osisTenant = new OsisTenant();
+        osisTenant.tenantId(null);
+        osisTenant.name(SAMPLE_TENANT_NAME);
+        osisTenant.cdTenantIds(SAMPLE_CD_TENANT_IDS);
+        osisTenant.active(true);
+
+        CreateAccountRequestDTO createAccountRequestDTO = ScalityModelConverter.toScalityAccountRequest(osisTenant);
+
+        assertNull(createAccountRequestDTO.getExternalAccountId(), "toScalityAccountRequestTest should throw Null Pointer :getExternalAccountId()");
+    }
+
+    @Test
+    public void toScalityAccountRequestActiveErr(){
+        OsisTenant osisTenant = new OsisTenant();
+        osisTenant.active(false);
+        assertThrows(BadRequestException.class, () -> {
+            ScalityModelConverter.toScalityAccountRequest(osisTenant);
+        }, "toScalityAccountRequestActiveErr should throw BadRequestException :toScalityAccountRequest()");
+    }
+
+    @Test
+    public void createAccountResponseToOsisTenantTest() throws Exception {
+
+        AccountData data = new AccountData();
+        data.setName(SAMPLE_TENANT_NAME);
+        data.setEmailAddress(SAMPLE_SCALITY_ACCOUNT_EMAIL);
+        data.setId(SAMPLE_TENANT_ID);
+        data.setCustomAttributes(SAMPLE_CUSTOM_ATTRIBUTES);
+        Account account = new Account();
+        account.setData(data);
+        CreateAccountResponseDTO responseDTO = new CreateAccountResponseDTO ();
+        responseDTO.setAccount(account);
+
+        //vault specific email address format for ose-scality
+        OsisTenant osisTenant = ScalityModelConverter.toOsisTenant(responseDTO);
+        assertEquals(SAMPLE_TENANT_ID, osisTenant.getTenantId(), "failed createAccountResponseToOsisTenantTest:getTenantId()");
+        assertEquals(SAMPLE_TENANT_NAME, osisTenant.getName(), "failed createAccountResponseToOsisTenantTest:getName()");
+        assertTrue(SAMPLE_CD_TENANT_IDS.size() == osisTenant.getCdTenantIds().size() &&
+                SAMPLE_CD_TENANT_IDS.containsAll(osisTenant.getCdTenantIds())
+                && osisTenant.getCdTenantIds().containsAll(SAMPLE_CD_TENANT_IDS), "failed createAccountResponseToOsisTenantTest:getCdTenantIds()");
+        assertTrue(osisTenant.getActive(), "failed createAccountResponseToOsisTenantTest:getActive()");
+    }
+}

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
@@ -1,0 +1,50 @@
+package com.scality.osis.utils;
+
+
+import com.vmware.osis.model.OsisTenant;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ScalityTestUtils {
+
+    public static final String SAMPLE_TENANT_ID = "12313265465789";
+    public static final String SAMPLE_ID = "bfc0d4a51e06481cbc917e9d96e52d81";
+    public static final String SAMPLE_TENANT_NAME = "tenant name";
+    public static final List<String> SAMPLE_CD_TENANT_IDS = new ArrayList<>(
+            Arrays.asList(
+                    "9b7e3259-aace-414c-bfd8-94daa0efefaf","7b7e3259-aace-414c-bfd8-94daa0efefaf",
+                    "5b7e3259-aace-414c-bfd8-94daa0efefaf","6b7e3259-aace-414c-bfd8-94daa0efefaf",
+                    "4b7e3259-aace-414c-bfd8-94daa0efefaf","3b7e3259-aace-414c-bfd8-94daa0efefaf")
+    );
+
+    public static final Map<String, String> SAMPLE_CUSTOM_ATTRIBUTES  = new HashMap<>() ;
+    static {
+        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id%3D%3D9b7e3259-aace-414c-bfd8-94daa0efefaf", "");
+        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id%3D%3D7b7e3259-aace-414c-bfd8-94daa0efefaf", "");
+        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id%3D%3D5b7e3259-aace-414c-bfd8-94daa0efefaf", "");
+        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id%3D%3D6b7e3259-aace-414c-bfd8-94daa0efefaf", "");
+        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id%3D%3D4b7e3259-aace-414c-bfd8-94daa0efefaf", "");
+        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id%3D%3D3b7e3259-aace-414c-bfd8-94daa0efefaf", "");
+    }
+
+
+
+    public static final String SAMPLE_SCALITY_ACCOUNT_EMAIL = "tenant.name@osis.scality.com";
+
+    public static final String SAMPLE_SCALITY_ACCOUNT_NAME ="tenant.name";
+
+
+
+    public static OsisTenant createSampleOsisTenantObj(){
+        OsisTenant osisTenantReq = new OsisTenant();
+        osisTenantReq.tenantId(SAMPLE_ID);
+        osisTenantReq.name(SAMPLE_TENANT_NAME);
+        osisTenantReq.cdTenantIds(SAMPLE_CD_TENANT_IDS);
+        osisTenantReq.active(true);
+        return osisTenantReq;
+    }
+}


### PR DESCRIPTION
- createTenant() in ScalityOsisService uses VaultAdmin class to create an account on Vault.
- ModelConverter class has the functionality to transform account response to tenant response and vice versa
- Implemented unit test cases for Create Tenant and various helper methods using mockito and Junit