### PR TITLE
feature:S3C-3551 getOsisUsage() API w/ no usage data

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisService.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisService.java
@@ -201,6 +201,6 @@ public class ScalityOsisService implements OsisService {
 
     @Override
     public OsisUsage getOsisUsage(Optional<String> tenantId, Optional<String> userId) {
-        throw new NotImplementedException();
+        return new OsisUsage();
     }
 }

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTest.java
@@ -512,7 +512,7 @@ public class ScalityOsisServiceTest {
         // Setup
 
         // Run the test
-        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getOsisUsage(Optional.of(TEST_STR), Optional.of(TEST_STR)), NOT_IMPLEMENTED_EXCEPTION_ERR);
+        assertNotNull(scalityOsisServiceUnderTest.getOsisUsage(Optional.of(TEST_STR), Optional.of(TEST_STR)), NULL_ERR);
 
         // Verify the results
 


### PR DESCRIPTION
Explanation: getOsisUsage() API with no usage data