### PR TITLE
feature:S3C-3527 [List Tenants] Implement in-memory cache for vault calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ sourceSets {
     }
 }
 
-configure(allprojects.findAll { it.name != 'vault-admin-client' }) {
+configure(allprojects) {
     ext {
         springBootVersion = '2.2.4.RELEASE'
     }

--- a/pmd-rules.xml
+++ b/pmd-rules.xml
@@ -31,6 +31,7 @@ http://pmd.sourceforge.net/ruleset/2.0.0 ">
 
     <rule ref="category/java/codestyle.xml">
         <exclude name="AtLeastOneConstructor"/>
+        <exclude name="UseUnderscoresInNumericLiterals"/>
     </rule>
     <rule ref="category/java/codestyle.xml/LongVariable">
         <properties>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,10 @@ osis.scality.vault.endpoint=http://192.168.1.10:8600
 osis.scality.vault.access-key=D4IT2AWSB588GO5J9T00
 osis.scality.vault.secret-key=UEEu8tYlsOGGrgf4DAiSZD6apVNPUWqRiPG0nTB6
 
+# Vault cache config
+osis.scality.vault.cache.listAccounts.disabled=false
+osis.scality.vault.cache.listAccounts.maxCapacity=1000
+
 # S3 Config
 osis.scality.s3.endpoint=http://scality.osis.ose.vmware.com:31383
 #osis.scality.s3.access-key=094BC4MZSZMET634FXZ0

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,7 @@ osis.scality.vault.secret-key=UEEu8tYlsOGGrgf4DAiSZD6apVNPUWqRiPG0nTB6
 # Vault cache config
 osis.scality.vault.cache.listAccounts.disabled=false
 osis.scality.vault.cache.listAccounts.maxCapacity=1000
+osis.scality.vault.cache.listAccounts.expirationInMS=60000
 
 # S3 Config
 osis.scality.s3.endpoint=http://scality.osis.ose.vmware.com:31383

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/ExternalServiceFactory.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/ExternalServiceFactory.java
@@ -6,6 +6,7 @@
 package com.scality.osis.vaultadmin.impl;
 
 import com.amazonaws.Response;
+import com.scality.osis.vaultadmin.utils.ErrorUtils;
 import com.scality.vaultclient.services.VaultClientException;
 
 import java.util.function.Function;

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/Cache.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/Cache.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2021 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.vaultadmin.impl.cache;
+
+public interface Cache<K,V> {
+    V put(K key, V value, long expireTime);
+    V put(K key, V value);
+    V remove(K key);
+    V get(K key);
+    void clear();
+    long size();
+    boolean containsKey(K key);
+}

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/Cache.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/Cache.java
@@ -6,11 +6,9 @@
 package com.scality.osis.vaultadmin.impl.cache;
 
 public interface Cache<K,V> {
-    V put(K key, V value, long expireTime);
     V put(K key, V value);
     V remove(K key);
     V get(K key);
     void clear();
     long size();
-    boolean containsKey(K key);
 }

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheConstants.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheConstants.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2021 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.vaultadmin.impl.cache;
+
+public final class CacheConstants {
+    //Env variables
+    public static final String ENV_LIST_ACCOUNT_DISABLED = "osis.scality.vault.cache.listAccounts.disabled";
+    public static final String ENV_LIST_ACCOUNT_MAX_CAPACITY = "osis.scality.vault.cache.listAccounts.maxCapacity";
+
+
+
+    // Defaults
+    public static final int DEFAULT_CACHE_MAX_CAPACITY = 1000;
+    public static final long DEFAULT_EXPIRY_TIME_IN_MS = 30000;
+    public static final int DEFAULT_SCHEDULED_THREAD_POOL_SIZE = 3;
+
+    //Constants
+    public static final String NAME_LIST_ACCOUNTS_CACHE = "listAccounts";
+
+    private CacheConstants(){}
+
+}

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheConstants.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheConstants.java
@@ -9,13 +9,14 @@ public final class CacheConstants {
     //Env variables
     public static final String ENV_LIST_ACCOUNT_DISABLED = "osis.scality.vault.cache.listAccounts.disabled";
     public static final String ENV_LIST_ACCOUNT_MAX_CAPACITY = "osis.scality.vault.cache.listAccounts.maxCapacity";
+    public static final String ENV_LIST_ACCOUNT_EXPIRATION = "osis.scality.vault.cache.listAccounts.expirationInMS";
 
 
 
     // Defaults
     public static final int DEFAULT_CACHE_MAX_CAPACITY = 1000;
     public static final long DEFAULT_EXPIRY_TIME_IN_MS = 30000;
-    public static final int DEFAULT_SCHEDULED_THREAD_POOL_SIZE = 3;
+    public static final int DEFAULT_SCHEDULED_THREAD_POOL_SIZE = 1;
 
     //Constants
     public static final String NAME_LIST_ACCOUNTS_CACHE = "listAccounts";

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheFactory.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheFactory.java
@@ -44,7 +44,10 @@ public class CacheFactory {
         if(!env.isListAccountsCacheDisabled()) {
             int maxCapacity = env.getListAccountsMaxCapacity() !=null
                     ? env.getListAccountsMaxCapacity() : DEFAULT_CACHE_MAX_CAPACITY;
-            listAccountsMarkerCache = new CacheImpl<>(maxCapacity);
+
+            long expirationTime = env.getListAccountsExpiration() !=null
+                    ? env.getListAccountsExpiration() : DEFAULT_CACHE_MAX_CAPACITY;
+            listAccountsMarkerCache = new CacheImpl<>(maxCapacity, expirationTime);
         }
     }
 

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheFactory.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheFactory.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2021 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.vaultadmin.impl.cache;
+
+import com.scality.osis.vaultadmin.utils.VaultAdminEnv;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.*;
+
+/**
+ * The factory class for all Caches.
+ */
+@Component
+public class CacheFactory {
+
+    @Autowired
+    private VaultAdminEnv env;
+
+    private Cache<Integer, String> listAccountsMarkerCache;
+
+    private CacheFactory(){
+
+        initListAccountsMarkerCache();
+
+    }
+
+    /**
+     * Instantiates a new Cache factory.
+     *
+     * @param env the env
+     */
+    public CacheFactory(VaultAdminEnv env){
+        this.env =env;
+        initListAccountsMarkerCache();
+
+    }
+
+    private void initListAccountsMarkerCache() {
+        // if listAccount cache not disabled
+        if(!env.isListAccountsCacheDisabled()) {
+            int maxCapacity = env.getListAccountsMaxCapacity() !=null
+                    ? env.getListAccountsMaxCapacity() : DEFAULT_CACHE_MAX_CAPACITY;
+            listAccountsMarkerCache = new CacheImpl<>(maxCapacity);
+        }
+    }
+
+    /**
+     * Get cache object using cache name.
+     *
+     * @param cacheName the cache name
+     * @return the cache object
+     */
+    public Cache getCache(String cacheName){
+        switch(cacheName){
+            case NAME_LIST_ACCOUNTS_CACHE : return listAccountsMarkerCache;
+        }
+        return null;
+    }
+
+}

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheImpl.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheImpl.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2021 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.vaultadmin.impl.cache;
+
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.*;
+
+/** CacheImpl is a thread-safe LRU cache implementation with expiration time for each entry
+ * <p>
+ * Using ConcurrentHashMap + ConcurrentLinkedQueue + ReadWriteLock + ScheduledExecutorService to implement thread-safe LRU caching
+ */
+public class CacheImpl<K, V> implements Cache<K,V> {
+
+    /**
+     * Maximum capacity of the cache
+     */
+    private final int maxCapacity;
+    private final Map<K, V> internalCache;
+    private final Queue<K> trackingQueue;
+
+    /**
+     * Read-write lock
+     */
+    private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+    private final Lock writeLock = readWriteLock.writeLock();
+    private final Lock readLock = readWriteLock.readLock();
+
+    private final ScheduledExecutorService scheduledExecutorService;
+
+    public CacheImpl(int maxCapacity){
+        if (maxCapacity < 0) {
+            throw new IllegalArgumentException("Illegal max capacity: " + maxCapacity);
+        }
+
+        this.maxCapacity = maxCapacity;
+        internalCache = new ConcurrentHashMap<>(maxCapacity);
+        trackingQueue = new ConcurrentLinkedQueue<>();
+        scheduledExecutorService = Executors.newScheduledThreadPool(DEFAULT_SCHEDULED_THREAD_POOL_SIZE);
+    }
+
+    /**
+     * @param key Key
+     * @return Value corresponding to the Key K in the map is returned or null
+     *         is returned if the key is not present in the map
+     */
+    @Override
+    public V get(K key) {
+        //Add read lock
+        readLock.lock();
+        try {
+            //whether the key exists in the current cache
+            V value = internalCache.get(key);
+            if (value != null) {
+                // If it exists, move the key to the end of the queue
+                if (trackingQueue.remove(key)) {
+                    trackingQueue.add(key);
+                }
+            }
+            return value;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * @param key Key
+     * @param value Value
+     * Entry with key k and value v is added to the Cache.
+     */
+    @Override
+    public V put(K key, V value) {
+        return put(key, value, DEFAULT_EXPIRY_TIME_IN_MS);
+    }
+
+    /**
+     * @param key Key
+     * @param value Value
+     * @param expireTime
+     *            Read and write lock with ConcurrentHashMap and
+     *            ConcurrentLinkedQueue to implement concurrent Lru Cache. Entry
+     *            with key k and value v is added to the Cache.
+     */
+    @Override
+    public V put(K key, V value, long expireTime) {
+        // add write lock
+        writeLock.lock();
+        try {
+            //1. If the key exists in the current cache, remove it from queue
+            if (internalCache.containsKey(key)) {
+                trackingQueue.remove(key);
+            }
+            //2. If the cache capacity is exceeded, remove the element at the head of the queue and cache
+            if (trackingQueue.size() == maxCapacity) {
+                K oldestKey = trackingQueue.poll();
+                if (oldestKey != null) {
+                    internalCache.remove(oldestKey);
+                }
+            }
+
+            //3.key does not exist in the current cache. Add the key to the end of the queue and cache the key and its corresponding elements
+            internalCache.put(key, value);
+            trackingQueue.add(key);
+
+            if (expireTime > 0) {
+                removeAfterExpireTime(key, expireTime);
+            }
+        } finally {
+            writeLock.unlock();
+        }
+        return value;
+    }
+
+    /**
+     * @param key Key
+     * @return Value corresponding to the key is returned if present in the map
+     *         else null is returned. Entry with key k is removed from the
+     *         cache.
+     */
+    @Override
+    public V remove(K key) {
+        writeLock.lock();
+        try {
+            //whether the key exists in the current cache
+            if (internalCache.containsKey(key)) {
+                // There is a corresponding Key in the removal queue and Map
+                trackingQueue.remove(key);
+                return internalCache.remove(key);
+            }
+            //Return Null if it does not exist in the current cache
+            return null;
+        } finally {
+            writeLock.unlock();
+        }
+
+    }
+
+    /**
+     * Clears the cache.
+     */
+    @Override
+    public void clear() {
+        writeLock.lock();
+        try {
+            internalCache.clear();
+            trackingQueue.clear();
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public long size() {
+        return internalCache.size();
+    }
+
+    private void removeAfterExpireTime(K key, long expireTime) {
+        scheduledExecutorService.schedule(() -> {
+            //Clear the key-value pair after expiration
+            internalCache.remove(key);
+            trackingQueue.remove(key);
+        }, expireTime, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Returns true if the Cache has a value associated with the specified key, else returns false;
+     * @param key The key to be checked
+     * @return true if the cache has a value mapped to the given key.
+     * */
+    @Override
+    public boolean containsKey(K key) {
+        return internalCache.containsKey(key);
+    }
+
+    @Override
+    public String toString() {
+        return "CacheImpl{" +
+                "internalCache=" + internalCache +
+                '}';
+    }
+}

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/utils/ErrorUtils.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/utils/ErrorUtils.java
@@ -3,19 +3,23 @@
  * SPDX-License-Identifier: Apache License 2.0
  */
 
-package com.scality.osis.vaultadmin.impl;
+package com.scality.osis.vaultadmin.utils;
 
+import com.scality.osis.vaultadmin.impl.VaultServiceException;
 import com.scality.vaultclient.services.VaultClientException;
 import com.amazonaws.http.HttpResponse;
 
-class ErrorUtils {
+public final class ErrorUtils {
+  private ErrorUtils(){
 
-  static VaultServiceException parseError(HttpResponse response) {
+  }
+
+  public static VaultServiceException parseError(HttpResponse response) {
       return new VaultServiceException(
               response.getStatusCode(), response.getStatusText());
   }
 
-  static VaultServiceException parseError(VaultClientException vaultClientException) {
+  public static VaultServiceException parseError(VaultClientException vaultClientException) {
       return new VaultServiceException(
               vaultClientException.getStatusCode(), vaultClientException.getErrorCode());
   }

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/utils/VaultAdminEnv.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/utils/VaultAdminEnv.java
@@ -45,4 +45,14 @@ public class VaultAdminEnv {
                 ? null : Integer.parseInt(env.getProperty(CacheConstants.ENV_LIST_ACCOUNT_MAX_CAPACITY));
     }
 
+    /**
+     * Get list accounts cache expiration time.
+     *
+     * @return the integer
+     */
+    public Long getListAccountsExpiration(){
+        return StringUtils.isEmpty(env.getProperty(CacheConstants.ENV_LIST_ACCOUNT_EXPIRATION))
+                ? null : Long.parseLong(env.getProperty(CacheConstants.ENV_LIST_ACCOUNT_EXPIRATION));
+    }
+
 }

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/utils/VaultAdminEnv.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/utils/VaultAdminEnv.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2021 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.vaultadmin.utils;
+
+import com.scality.osis.vaultadmin.impl.cache.CacheConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Class for Vault admin environment variables.
+ */
+@Component
+public class VaultAdminEnv {
+    /**
+     * Instantiates a new Vault admin env.
+     */
+    public VaultAdminEnv(){
+
+    }
+
+    @Autowired
+    private Environment env;
+
+    /**
+     * Is list accounts cache disabled boolean.
+     *
+     * @return the boolean
+     */
+    public boolean isListAccountsCacheDisabled(){
+        return Boolean.parseBoolean(env.getProperty(CacheConstants.ENV_LIST_ACCOUNT_DISABLED));
+    }
+
+    /**
+     * Get list accounts max capacity integer.
+     *
+     * @return the integer
+     */
+    public Integer getListAccountsMaxCapacity(){
+       return StringUtils.isEmpty(env.getProperty(CacheConstants.ENV_LIST_ACCOUNT_MAX_CAPACITY))
+                ? null : Integer.parseInt(env.getProperty(CacheConstants.ENV_LIST_ACCOUNT_MAX_CAPACITY));
+    }
+
+}

--- a/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/cache/CacheFactoryTest.java
+++ b/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/cache/CacheFactoryTest.java
@@ -1,0 +1,58 @@
+package com.scality.osis.vaultadmin.impl.cache;
+
+import com.scality.osis.vaultadmin.utils.VaultAdminEnv;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.DEFAULT_CACHE_MAX_CAPACITY;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.NAME_LIST_ACCOUNTS_CACHE;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class CacheFactoryTest {
+
+    private CacheFactory cacheFactoryUnderTest;
+
+    @Mock
+    private VaultAdminEnv envMock;
+
+    @BeforeEach
+    public void setUp() {
+
+        initMocks();
+        cacheFactoryUnderTest = new CacheFactory(envMock);
+    }
+
+    private void initMocks() {
+
+        envMock = Mockito.mock(VaultAdminEnv.class);
+        // Setup
+        when(envMock.getListAccountsMaxCapacity()).thenReturn(DEFAULT_CACHE_MAX_CAPACITY);
+        when(envMock.isListAccountsCacheDisabled()).thenReturn(false);
+    }
+
+    @Test
+    public void testGetCache() {
+        // Setup
+
+        // Run the test
+        final Cache result = cacheFactoryUnderTest.getCache(NAME_LIST_ACCOUNTS_CACHE);
+
+        // Verify the results
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetCacheInvalidValue() {
+        // Setup
+
+        // Run the test
+        final Cache result = cacheFactoryUnderTest.getCache("dummy");
+
+        // Verify the results
+        assertNull(result);
+    }
+}

--- a/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/cache/CacheImplTest.java
+++ b/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/cache/CacheImplTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class CacheImplTest {
@@ -20,12 +19,12 @@ public class CacheImplTest {
 
     @BeforeAll
     public static void setUp() {
-        cacheImplUnderTest = new CacheImpl<>(3);
+        cacheImplUnderTest = new CacheImpl<>(1, 30000L);
     }
 
     @Test
     @Order(1)
-    public void testPut1() {
+    public void testPut() {
         // Setup
         final String key = "Key1";
         final String value = "Value";
@@ -39,20 +38,6 @@ public class CacheImplTest {
 
     @Test
     @Order(2)
-    public void testPutWithExpiry() {
-        // Setup
-        final String key = "Key2";
-        final String value = "Value2";
-
-        // Run the test
-        final String result = cacheImplUnderTest.put(key, value, 30L);
-
-        // Verify the results
-        assertEquals(value, result);
-    }
-
-    @Test
-    @Order(3)
     public void testGet() {
         // Setup
         final String key = "Key1";
@@ -65,39 +50,42 @@ public class CacheImplTest {
     }
 
     @Test
-    @Order(4)
+    @Order(3)
     public void testPutWithQuickExpiry() throws InterruptedException {
         // Setup
         final String key = "Key3";
         final String value = "Value3";
 
+        final CacheImpl<String, String> cacheImplUnderTest1 = new CacheImpl<>(1, 200);
         // Run the test
-        final String result = cacheImplUnderTest.put(key, value, 1);
+        final String result = cacheImplUnderTest1.put(key, value);
 
         // Verify the results
-        Thread.sleep(1);
+        Thread.sleep(205);
         assertEquals(value, result);
-        assertNull(cacheImplUnderTest.get(key));
+        assertNull(cacheImplUnderTest1.get(key));
     }
 
     @Test
-    @Order(5)
+    @Order(4)
     public void testRemove() {
         // Setup
-        final String key = "Key2";
+        final String key = "Key1";
 
         // Run the test
         final String result = cacheImplUnderTest.remove(key);
 
         // Verify the results
-        assertEquals("Value2", result);
+        assertEquals("Value", result);
     }
 
     @Test
-    @Order(6)
+    @Order(5)
     public void testSize() {
         // Setup
 
+        // Run the test
+        cacheImplUnderTest.put("Key1", "Value");
         // Run the test
         final long result = cacheImplUnderTest.size();
 
@@ -106,20 +94,7 @@ public class CacheImplTest {
     }
 
     @Test
-    @Order(7)
-    public void testContainsKey() {
-        // Setup
-        final String key = "Key1";
-
-        // Run the test
-        final boolean result = cacheImplUnderTest.containsKey(key);
-
-        // Verify the results
-        assertTrue(result);
-    }
-
-    @Test
-    @Order(8)
+    @Order(6)
     public void testToString() {
         // Setup
 
@@ -131,7 +106,7 @@ public class CacheImplTest {
     }
 
     @Test
-    @Order(9)
+    @Order(7)
     public void testClear() {
         // Setup
 
@@ -165,14 +140,24 @@ public class CacheImplTest {
     }
 
     @Test
+    public void testIllegalExpirationTime() {
+        // Setup
+        // Run the test
+        // Verify the results
+        assertThrows(IllegalArgumentException.class, () -> {
+            new CacheImpl<>(1, -100L);
+        });
+    }
+
+    @Test
     public void testPutExistingKey() {
         // Setup
         final String key = "Key2";
         final String value = "Value2";
 
         // Run the test
-        final String value1 = cacheImplUnderTest.put(key, value, 30L);
-        final String result = cacheImplUnderTest.put(key, value, 30L);
+        final String value1 = cacheImplUnderTest.put(key, value);
+        final String result = cacheImplUnderTest.put(key, value);
 
         // Verify the results
         assertEquals(value1, result);
@@ -189,11 +174,11 @@ public class CacheImplTest {
 
         final CacheImpl<String, String> cacheImplUnderTest2 = new CacheImpl<>(maxCapacity);
         for(int index=0; index< maxCapacity; index++){
-            cacheImplUnderTest2.put(key + index, value, 30000);
+            cacheImplUnderTest2.put(key + index, value);
         }
 
         // Insert extra value higher than maxCapacity
-        cacheImplUnderTest2.put("newKey", value, 30L);
+        cacheImplUnderTest2.put("newKey", value);
 
         // Verify the results
         assertEquals(maxCapacity, cacheImplUnderTest2.size());

--- a/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/cache/CacheImplTest.java
+++ b/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/cache/CacheImplTest.java
@@ -1,0 +1,201 @@
+package com.scality.osis.vaultadmin.impl.cache;
+
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class CacheImplTest {
+
+    private static CacheImpl<String, String> cacheImplUnderTest;
+
+    @BeforeAll
+    public static void setUp() {
+        cacheImplUnderTest = new CacheImpl<>(3);
+    }
+
+    @Test
+    @Order(1)
+    public void testPut1() {
+        // Setup
+        final String key = "Key1";
+        final String value = "Value";
+
+        // Run the test
+        final String result = cacheImplUnderTest.put(key, value);
+
+        // Verify the results
+        assertEquals(value, result);
+    }
+
+    @Test
+    @Order(2)
+    public void testPutWithExpiry() {
+        // Setup
+        final String key = "Key2";
+        final String value = "Value2";
+
+        // Run the test
+        final String result = cacheImplUnderTest.put(key, value, 30L);
+
+        // Verify the results
+        assertEquals(value, result);
+    }
+
+    @Test
+    @Order(3)
+    public void testGet() {
+        // Setup
+        final String key = "Key1";
+
+        // Run the test
+        final String result = cacheImplUnderTest.get(key);
+
+        // Verify the results
+        assertEquals("Value", result);
+    }
+
+    @Test
+    @Order(4)
+    public void testPutWithQuickExpiry() throws InterruptedException {
+        // Setup
+        final String key = "Key3";
+        final String value = "Value3";
+
+        // Run the test
+        final String result = cacheImplUnderTest.put(key, value, 1);
+
+        // Verify the results
+        Thread.sleep(1);
+        assertEquals(value, result);
+        assertNull(cacheImplUnderTest.get(key));
+    }
+
+    @Test
+    @Order(5)
+    public void testRemove() {
+        // Setup
+        final String key = "Key2";
+
+        // Run the test
+        final String result = cacheImplUnderTest.remove(key);
+
+        // Verify the results
+        assertEquals("Value2", result);
+    }
+
+    @Test
+    @Order(6)
+    public void testSize() {
+        // Setup
+
+        // Run the test
+        final long result = cacheImplUnderTest.size();
+
+        // Verify the results
+        assertThat(result).isEqualTo(1);
+    }
+
+    @Test
+    @Order(7)
+    public void testContainsKey() {
+        // Setup
+        final String key = "Key1";
+
+        // Run the test
+        final boolean result = cacheImplUnderTest.containsKey(key);
+
+        // Verify the results
+        assertTrue(result);
+    }
+
+    @Test
+    @Order(8)
+    public void testToString() {
+        // Setup
+
+        // Run the test
+        final String result = cacheImplUnderTest.toString();
+
+        // Verify the results
+        assertThat(result).isEqualTo("CacheImpl{internalCache={Key1=Value}}");
+    }
+
+    @Test
+    @Order(9)
+    public void testClear() {
+        // Setup
+
+        // Run the test
+        cacheImplUnderTest.clear();
+
+        // Verify the results
+        assertEquals(0, cacheImplUnderTest.size());
+    }
+
+    @Test
+    public void testRemove2() {
+        // Setup
+        final String key = "KeyNull";
+
+        // Run the test with invalid key
+        final String result = cacheImplUnderTest.remove(key);
+
+        // Verify the results
+        assertNull(result);
+    }
+
+    @Test
+    public void testIllegalMaxCapacity() {
+        // Setup
+        // Run the test
+        // Verify the results
+        assertThrows(IllegalArgumentException.class, () -> {
+            new CacheImpl<>(-3);
+        });
+    }
+
+    @Test
+    public void testPutExistingKey() {
+        // Setup
+        final String key = "Key2";
+        final String value = "Value2";
+
+        // Run the test
+        final String value1 = cacheImplUnderTest.put(key, value, 30L);
+        final String result = cacheImplUnderTest.put(key, value, 30L);
+
+        // Verify the results
+        assertEquals(value1, result);
+    }
+
+    @Test
+    @Order(7)
+    public void testPutMaxKeys() {
+        // Setup
+
+        final int maxCapacity = 10;
+        final String key = "Key";
+        final String value = "Value";
+
+        final CacheImpl<String, String> cacheImplUnderTest2 = new CacheImpl<>(maxCapacity);
+        for(int index=0; index< maxCapacity; index++){
+            cacheImplUnderTest2.put(key + index, value, 30000);
+        }
+
+        // Insert extra value higher than maxCapacity
+        cacheImplUnderTest2.put("newKey", value, 30L);
+
+        // Verify the results
+        assertEquals(maxCapacity, cacheImplUnderTest2.size());
+    }
+}

--- a/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/utils/VaultAdminEnvTest.java
+++ b/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/utils/VaultAdminEnvTest.java
@@ -1,0 +1,47 @@
+package com.scality.osis.vaultadmin.utils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.core.env.Environment;
+
+import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.DEFAULT_CACHE_MAX_CAPACITY;
+import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.ENV_LIST_ACCOUNT_DISABLED;
+import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.ENV_LIST_ACCOUNT_MAX_CAPACITY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class VaultAdminEnvTest {
+
+    @Mock
+    private Environment envMock;
+
+    @InjectMocks
+    private VaultAdminEnv vaultAdminEnv;
+
+    @BeforeEach
+    public void setup(){
+        initMocks(this);
+    }
+
+    @Test
+    public void testIsListAccountsCacheDisabled() {
+        // Setup
+        when(envMock.getProperty(ENV_LIST_ACCOUNT_DISABLED)).thenReturn(Boolean.FALSE.toString());
+
+        // Run the test
+        assertFalse(vaultAdminEnv.isListAccountsCacheDisabled());
+    }
+
+    @Test
+    public void testGetListAccountsMaxCapacity() {
+        // Setup
+        when(envMock.getProperty(ENV_LIST_ACCOUNT_MAX_CAPACITY)).thenReturn(DEFAULT_CACHE_MAX_CAPACITY + "");
+
+        // Run the test
+        assertEquals(DEFAULT_CACHE_MAX_CAPACITY, vaultAdminEnv.getListAccountsMaxCapacity());
+    }
+}


### PR DESCRIPTION
Description:
* Implemented a thread-safe LRU cache with expiration time for each entry
* Created a Cache Factory that produces the Cache for each vault service
* cache properties can be loaded from environment variables i.e.,`application.properties`