### PR TITLE
feature:S3C-3527 [List Tenants] Implementation and Unit Tests

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -12,7 +12,7 @@ public final class ScalityConstants {
 
     public static final String TENANT_EMAIL_SUFFIX = "@osis.scality.com";
 
-    public static final String CD_TENANT_ID_PREFIX = "cd_tenant_id%3D%3D";
+    public static final String CD_TENANT_ID_PREFIX = "cd_tenant_id==";
 
     public static final String SEPARATOR = ".";
 

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -60,7 +60,7 @@ public final class ScalityModelConverter {
     }
 
     /**
-     * Created Vault List Accounts request
+     * Created Vault List Accounts request for List Tenants
      * @param limit the max number of items
      *
      * @return the create account request dto
@@ -88,8 +88,8 @@ public final class ScalityModelConverter {
      *
      * @param cdTenantIds the cd tenant ids list. Example:<code>["9b7e3259-aace-414c-bfd8-94daa0efefaf","7b7e3259-aace-414c-bfd8-94daa0efefaf"]</code>
      * @return the customAttributes map.
-     *          Example: <code>{("cd_tenant_id%3D%3D9b7e3259-aace-414c-bfd8-94daa0efefaf", ""),
-     *                          ("cd_tenant_id%3D%3D7b7e3259-aace-414c-bfd8-94daa0efefaf", "")}</code>
+     *          Example: <code>{("cd_tenant_id==9b7e3259-aace-414c-bfd8-94daa0efefaf", ""),
+     *                          ("cd_tenant_id==7b7e3259-aace-414c-bfd8-94daa0efefaf", "")}</code>
      */
     public static Map<String,String> toScalityCustomAttributes(List<String> cdTenantIds) {
         return cdTenantIds.stream()
@@ -126,8 +126,8 @@ public final class ScalityModelConverter {
      * Converts Vault Account customAttributes Map Format to OSIS cdTenantIDs list.
      *
      * @param customAttributes the customAttributes map.
-     *      *          Example: <code>{("cd_tenant_id%3D%3D9b7e3259-aace-414c-bfd8-94daa0efefaf", ""),
-     *      *                          ("cd_tenant_id%3D%3D7b7e3259-aace-414c-bfd8-94daa0efefaf", "")}</code>
+     *      *          Example: <code>{("cd_tenant_id==9b7e3259-aace-414c-bfd8-94daa0efefaf", ""),
+     *      *                          ("cd_tenant_id==7b7e3259-aace-414c-bfd8-94daa0efefaf", "")}</code>
      * @return the cd tenant ids list. Example:<code>["9b7e3259-aace-414c-bfd8-94daa0efefaf","7b7e3259-aace-414c-bfd8-94daa0efefaf"]</code>
      */
     public static List<String> toOsisCDTenantIds(Map<String,String> customAttributes) {

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTest.java
@@ -118,7 +118,7 @@ public class ScalityOsisServiceTest {
 
                         // if filterStartsWith generate customAttributes for all accounts
                         final Map<String, String> customAttributestemp  = new HashMap<>() ;
-                        customAttributestemp.put("cd_tenant_id%3D%3D" + UUID.randomUUID(), "");
+                        customAttributestemp.put("cd_tenant_id==" + UUID.randomUUID(), "");
                         data.setCustomAttributes(customAttributestemp);
                         accounts.add(data);
                     }

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
@@ -23,12 +23,12 @@ public final class ScalityTestUtils {
 
     public static final Map<String, String> SAMPLE_CUSTOM_ATTRIBUTES  = new HashMap<>() ;
     static {
-        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id%3D%3D9b7e3259-aace-414c-bfd8-94daa0efefaf", "");
-        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id%3D%3D7b7e3259-aace-414c-bfd8-94daa0efefaf", "");
-        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id%3D%3D5b7e3259-aace-414c-bfd8-94daa0efefaf", "");
-        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id%3D%3D6b7e3259-aace-414c-bfd8-94daa0efefaf", "");
-        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id%3D%3D4b7e3259-aace-414c-bfd8-94daa0efefaf", "");
-        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id%3D%3D3b7e3259-aace-414c-bfd8-94daa0efefaf", "");
+        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id==9b7e3259-aace-414c-bfd8-94daa0efefaf", "");
+        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id==7b7e3259-aace-414c-bfd8-94daa0efefaf", "");
+        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id==5b7e3259-aace-414c-bfd8-94daa0efefaf", "");
+        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id==6b7e3259-aace-414c-bfd8-94daa0efefaf", "");
+        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id==4b7e3259-aace-414c-bfd8-94daa0efefaf", "");
+        SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id==3b7e3259-aace-414c-bfd8-94daa0efefaf", "");
     }
 
 

--- a/pmd-rules.xml
+++ b/pmd-rules.xml
@@ -46,11 +46,7 @@ http://pmd.sourceforge.net/ruleset/2.0.0 ">
 
     <rule ref="category/java/design.xml">
         <exclude name="LawOfDemeter"/>
-    </rule>
-    <rule ref="category/java/design.xml/TooManyMethods">
-        <properties>
-            <property name="maxmethods" value="35" />
-        </properties>
+        <exclude name="TooManyMethods"/>
     </rule>
 
 </ruleset>

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/VaultAdmin.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/VaultAdmin.java
@@ -47,4 +47,13 @@ public interface VaultAdmin {
    * @return the list accounts response dto
    */
   ListAccountsResponseDTO listAccounts(ListAccountsRequestDTO listAccountsRequest);
+
+  /**
+   * List accounts
+   *
+   * @param offset the start index of accounts to return
+   * @param listAccountsRequest the list accounts request dto
+   * @return the list accounts response dto
+   */
+  ListAccountsResponseDTO listAccounts(long offset, ListAccountsRequestDTO listAccountsRequest);
 }

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheFactory.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheFactory.java
@@ -64,4 +64,8 @@ public class CacheFactory {
         return null;
     }
 
+    public VaultAdminEnv getEnvironmentVariables(){
+        return env;
+    }
+
 }

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheFactory.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/cache/CacheFactory.java
@@ -9,6 +9,8 @@ import com.scality.osis.vaultadmin.utils.VaultAdminEnv;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
+
 import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.*;
 
 /**
@@ -24,8 +26,6 @@ public class CacheFactory {
 
     private CacheFactory(){
 
-        initListAccountsMarkerCache();
-
     }
 
     /**
@@ -39,6 +39,7 @@ public class CacheFactory {
 
     }
 
+    @PostConstruct
     private void initListAccountsMarkerCache() {
         // if listAccount cache not disabled
         if(!env.isListAccountsCacheDisabled()) {

--- a/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/BaseTest.java
+++ b/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/BaseTest.java
@@ -140,7 +140,7 @@ public class BaseTest {
                   if(withcdTenantId){
                     // if filterStartsWith generate customAttributes for all accounts
                     final Map<String, String> customAttributestemp  = new HashMap<>() ;
-                    customAttributestemp.put("cd_tenant_id%3D%3D" + UUID.randomUUID(), "");
+                    customAttributestemp.put("cd_tenant_id==" + UUID.randomUUID(), "");
                     data.setCustomAttributes(customAttributestemp);
                   } else {
                     data.setCustomAttributes(customAttributes1);

--- a/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/BaseTest.java
+++ b/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/BaseTest.java
@@ -122,7 +122,7 @@ public class BaseTest {
                 int index = 0;
                 int markerVal = 0;
                 if(StringUtils.isNotBlank(marker)){
-                  markerVal = Integer.parseInt(marker.substring(marker.length()-1));
+                  markerVal = Integer.parseInt(marker.substring(marker.indexOf("M")+1));
                   // extracting markerVal index at last character
                 }
 
@@ -150,6 +150,8 @@ public class BaseTest {
                 }
 
                 final ListAccountsResponseDTO response = new ListAccountsResponseDTO();
+                response.setMarker("M"+(markerVal+maxItems));
+                response.setTruncated(true);
                 response.setAccounts(accounts);
 
                 final HttpResponse httpResponse = new HttpResponse(null, null);

--- a/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/VaultAdminImplTest.java
+++ b/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/VaultAdminImplTest.java
@@ -2,16 +2,22 @@ package com.scality.osis.vaultadmin.impl;
 
 import com.amazonaws.Response;
 import com.amazonaws.http.HttpResponse;
+import com.scality.osis.vaultadmin.impl.cache.CacheFactory;
+import com.scality.osis.vaultadmin.impl.cache.CacheImpl;
 import com.scality.vaultclient.dto.CreateAccountRequestDTO;
 import com.scality.vaultclient.dto.CreateAccountResponseDTO;
 import com.scality.vaultclient.dto.ListAccountsRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsResponseDTO;
+import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import java.io.IOException;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.DEFAULT_CACHE_MAX_CAPACITY;
+import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.NAME_LIST_ACCOUNTS_CACHE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -23,6 +29,9 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("ConstantConditions")
 public class VaultAdminImplTest extends BaseTest {
+
+
+    public static final String CD_TENANT_ID_PREFIX = "cd_tenant_id%3D%3D";
     @Test
     public void createAccount() {
 
@@ -131,9 +140,8 @@ public class VaultAdminImplTest extends BaseTest {
     public void listAccounts() {
 
         final ListAccountsRequestDTO   listAccountsRequestDTO = ListAccountsRequestDTO.builder()
-                .marker("0")
                 .maxItems(5)
-                .filterKeyStartsWith("cd_tenant_id%3D%3D")
+                .filterKeyStartsWith(CD_TENANT_ID_PREFIX)
                 .build();
 
         final ListAccountsResponseDTO response = vaultAdminImpl.listAccounts(listAccountsRequestDTO);
@@ -142,16 +150,15 @@ public class VaultAdminImplTest extends BaseTest {
         assertTrue(response.getAccounts().get(0)
                 .getCustomAttributes().keySet()
                 .stream().findFirst().get()
-                .startsWith("cd_tenant_id%3D%3D"));
+                .startsWith(CD_TENANT_ID_PREFIX));
     }
 
     @Test
     public void listAccounts400ServiceResponse() {
 
         final ListAccountsRequestDTO   listAccountsRequestDTO = ListAccountsRequestDTO.builder()
-                .marker("0")
                 .maxItems(5)
-                .filterKeyStartsWith("cd_tenant_id%3D%3D")
+                .filterKeyStartsWith(CD_TENANT_ID_PREFIX)
                 .build();
 
         when(accountServicesClient.listAccounts(any(ListAccountsRequestDTO.class)))
@@ -176,9 +183,8 @@ public class VaultAdminImplTest extends BaseTest {
     public void listAccounts500ServiceResponse() {
 
         final ListAccountsRequestDTO   listAccountsRequestDTO = ListAccountsRequestDTO.builder()
-                .marker("0")
                 .maxItems(5)
-                .filterKeyStartsWith("cd_tenant_id%3D%3D")
+                .filterKeyStartsWith(CD_TENANT_ID_PREFIX)
                 .build();
 
         when(accountServicesClient.listAccounts(any(ListAccountsRequestDTO.class)))
@@ -204,5 +210,128 @@ public class VaultAdminImplTest extends BaseTest {
         assertThrows(IllegalArgumentException.class,
                 () -> new VaultAdminImpl(accountServicesClient, "dummy_endpoint"),
                 "VaultAdminImpl constructor should throw IllegalArgumentException for null endpoint");
+    }
+
+    @Test
+    public void testGetListAccountsMarkerCacheEmpty() {
+
+        final CacheFactory cacheFactoryMock = Mockito.mock(CacheFactory.class);
+        when(cacheFactoryMock.getCache(NAME_LIST_ACCOUNTS_CACHE)).thenReturn(new CacheImpl<>(DEFAULT_CACHE_MAX_CAPACITY));
+
+        ReflectionTestUtils.setField(vaultAdminImpl, "cacheFactory", cacheFactoryMock);
+        vaultAdminImpl.initCaches();
+
+        final String marker = vaultAdminImpl.getAccountsMarker(1000, CD_TENANT_ID_PREFIX);
+        assertEquals("M1000", marker);
+    }
+
+    @Test
+    public void testGetListAccountsMarkerWithExistingCache1() {
+
+        final CacheFactory cacheFactoryMock = Mockito.mock(CacheFactory.class);
+        final CacheImpl<Integer, String> cache = new CacheImpl<>(DEFAULT_CACHE_MAX_CAPACITY);
+        cache.put(1000,"M1000");
+        cache.put(2000,"M2000");
+        cache.put(4000,"M4000");
+        when(cacheFactoryMock.getCache(NAME_LIST_ACCOUNTS_CACHE)).thenReturn(cache);
+
+        ReflectionTestUtils.setField(vaultAdminImpl, "cacheFactory", cacheFactoryMock);
+        vaultAdminImpl.initCaches();
+
+        final String marker = vaultAdminImpl.getAccountsMarker(3000, CD_TENANT_ID_PREFIX);
+        assertEquals("M3000", marker);
+    }
+
+    @Test
+    public void testGetListAccountsMarkerWithExistingCache2() {
+
+        final CacheFactory cacheFactoryMock = Mockito.mock(CacheFactory.class);
+        final CacheImpl<Integer, String> cache = new CacheImpl<>(DEFAULT_CACHE_MAX_CAPACITY);
+        cache.put(1000,"M1000");
+        cache.put(4000,"M4000");
+        when(cacheFactoryMock.getCache(NAME_LIST_ACCOUNTS_CACHE)).thenReturn(cache);
+
+        ReflectionTestUtils.setField(vaultAdminImpl, "cacheFactory", cacheFactoryMock);
+        vaultAdminImpl.initCaches();
+
+        final String marker = vaultAdminImpl.getAccountsMarker(500, CD_TENANT_ID_PREFIX);
+        assertEquals("M500", marker);
+    }
+
+    @Test
+    public void testListAccountsOffsetEmptyCache() {
+
+        final CacheFactory cacheFactoryMock = Mockito.mock(CacheFactory.class);
+        when(cacheFactoryMock.getCache(NAME_LIST_ACCOUNTS_CACHE)).thenReturn(new CacheImpl<>(DEFAULT_CACHE_MAX_CAPACITY));
+
+        ReflectionTestUtils.setField(vaultAdminImpl, "cacheFactory", cacheFactoryMock);
+        vaultAdminImpl.initCaches();
+
+        final ListAccountsRequestDTO   listAccountsRequestDTO = ListAccountsRequestDTO.builder()
+                .maxItems(1000)
+                .filterKeyStartsWith(CD_TENANT_ID_PREFIX)
+                .build();
+
+        final ListAccountsResponseDTO response = vaultAdminImpl.listAccounts(3000, listAccountsRequestDTO);
+        assertEquals(1000, response.getAccounts().size());
+        assertFalse(response.getAccounts().get(0).getCustomAttributes().isEmpty());
+        assertTrue(response.getAccounts().get(0)
+                .getCustomAttributes().keySet()
+                .stream().findFirst().get()
+                .startsWith(CD_TENANT_ID_PREFIX));
+    }
+
+    @Test
+    public void testListAccountsOffsetWithCache1() {
+
+        final CacheFactory cacheFactoryMock = Mockito.mock(CacheFactory.class);
+        final CacheImpl<Integer, String> cache = new CacheImpl<>(DEFAULT_CACHE_MAX_CAPACITY);
+        cache.put(1000,"M1000");
+        cache.put(2000,"M2000");
+        when(cacheFactoryMock.getCache(NAME_LIST_ACCOUNTS_CACHE)).thenReturn(cache);
+
+        ReflectionTestUtils.setField(vaultAdminImpl, "cacheFactory", cacheFactoryMock);
+        vaultAdminImpl.initCaches();
+
+        final ListAccountsRequestDTO   listAccountsRequestDTO = ListAccountsRequestDTO.builder()
+                .maxItems(1000)
+                .filterKeyStartsWith(CD_TENANT_ID_PREFIX)
+                .build();
+
+        final ListAccountsResponseDTO response = vaultAdminImpl.listAccounts(1000, listAccountsRequestDTO);
+        assertEquals(1000, response.getAccounts().size());
+        assertEquals("M2000", response.getMarker());
+        assertFalse(response.getAccounts().get(0).getCustomAttributes().isEmpty());
+        assertTrue(response.getAccounts().get(0)
+                .getCustomAttributes().keySet()
+                .stream().findFirst().get()
+                .startsWith(CD_TENANT_ID_PREFIX));
+    }
+
+    @Test
+    public void testListAccountsOffsetWithCache2() {
+
+        final CacheFactory cacheFactoryMock = Mockito.mock(CacheFactory.class);
+        final CacheImpl<Integer, String> cache = new CacheImpl<>(DEFAULT_CACHE_MAX_CAPACITY);
+        cache.put(1000,"M1000");
+        cache.put(4000,"M4000");
+        when(cacheFactoryMock.getCache(NAME_LIST_ACCOUNTS_CACHE)).thenReturn(cache);
+
+        ReflectionTestUtils.setField(vaultAdminImpl, "cacheFactory", cacheFactoryMock);
+        vaultAdminImpl.initCaches();
+
+        final ListAccountsRequestDTO   listAccountsRequestDTO = ListAccountsRequestDTO.builder()
+                .maxItems(1000)
+                .filterKeyStartsWith(CD_TENANT_ID_PREFIX)
+                .build();
+
+        final ListAccountsResponseDTO response = vaultAdminImpl.listAccounts(3000, listAccountsRequestDTO);
+        assertEquals(1000, response.getAccounts().size());
+        assertEquals("M4000", response.getMarker());
+        assertFalse(response.getAccounts().get(0).getCustomAttributes().isEmpty());
+        assertTrue(response.getAccounts().get(0)
+                .getCustomAttributes().keySet()
+                .stream().findFirst().get()
+                .startsWith(CD_TENANT_ID_PREFIX));
     }
 }

--- a/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/VaultAdminImplTest.java
+++ b/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/VaultAdminImplTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 public class VaultAdminImplTest extends BaseTest {
 
 
-    public static final String CD_TENANT_ID_PREFIX = "cd_tenant_id%3D%3D";
+    public static final String CD_TENANT_ID_PREFIX = "cd_tenant_id";
     @Test
     public void createAccount() {
 

--- a/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/utils/VaultAdminEnvTest.java
+++ b/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/utils/VaultAdminEnvTest.java
@@ -7,7 +7,9 @@ import org.mockito.Mock;
 import org.springframework.core.env.Environment;
 
 import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.DEFAULT_CACHE_MAX_CAPACITY;
+import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.DEFAULT_EXPIRY_TIME_IN_MS;
 import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.ENV_LIST_ACCOUNT_DISABLED;
+import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.ENV_LIST_ACCOUNT_EXPIRATION;
 import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.ENV_LIST_ACCOUNT_MAX_CAPACITY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -43,5 +45,14 @@ public class VaultAdminEnvTest {
 
         // Run the test
         assertEquals(DEFAULT_CACHE_MAX_CAPACITY, vaultAdminEnv.getListAccountsMaxCapacity());
+    }
+
+    @Test
+    public void testGetListAccountsExpiration() {
+        // Setup
+        when(envMock.getProperty(ENV_LIST_ACCOUNT_EXPIRATION)).thenReturn((int)DEFAULT_EXPIRY_TIME_IN_MS + "");
+
+        // Run the test
+        assertEquals((int)DEFAULT_EXPIRY_TIME_IN_MS, vaultAdminEnv.getListAccountsExpiration());
     }
 }


### PR DESCRIPTION
Description:
* Implements List Tenants API using marker cache
* Compute Marker for the given offset from cache or by calling Vault list accounts
* Convert request and response from OSIS List Tenants to and from Vault List Accounts format
* Mock Vault List Accounts responses including marker scenarios
* Mock Vault responses for List Tenants calls