### PR TITLE
feature:S3C-4200 Assume role backbeat API Integration - 2

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisService.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisService.java
@@ -6,6 +6,7 @@
 
 package com.scality.osis.service.impl;
 
+import com.amazonaws.services.securitytoken.model.Credentials;
 import com.scality.osis.ScalityAppEnv;
 import com.scality.osis.utils.ScalityUtils;
 import com.google.gson.Gson;
@@ -295,5 +296,9 @@ public class ScalityOsisService implements OsisService {
     @Override
     public OsisUsage getOsisUsage(Optional<String> tenantId, Optional<String> userId) {
         return new OsisUsage();
+    }
+
+    public Credentials getCredentials(String accountID) {
+        return vaultAdmin.getTempAccountCredentials(ScalityModelConverter.getAssumeRoleRequestForAccount(accountID, appEnv.getAssumeRoleName()));
     }
 }

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -14,6 +14,14 @@ public final class ScalityConstants {
 
     public static final String CD_TENANT_ID_PREFIX = "cd_tenant_id==";
 
+    public static final String ROLE_ARN_FORMAT = "arn:aws:iam::$ACCOUNTID:role/$ROLENAME";
+
+    public static final String ACCOUNT_ID_REGEX = "$ACCOUNTID";
+
+    public static final String ROLE_NAME_REGEX = "$ROLENAME";
+
+    public static final String ROLE_SESSION_NAME_PREFIX = "ROLE_SESSION_";
+
     public static final String SEPARATOR = ".";
 
     public static final String ICON_PATH = "/scalitylogo.png";

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -5,6 +5,7 @@
 
 package com.scality.osis.utils;
 
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.scality.vaultclient.dto.ListAccountsRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsResponseDTO;
 import com.vmware.osis.model.OsisTenant;
@@ -17,6 +18,7 @@ import com.scality.vaultclient.dto.CreateAccountResponseDTO;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -86,6 +88,18 @@ public final class ScalityModelConverter {
     }
 
     /**
+     * Creates Vault Assume Role request request for given account id
+     * @param accountID the account ID
+     *
+     * @return the assume role request dto
+     */
+    public static AssumeRoleRequest getAssumeRoleRequestForAccount(String accountID, String roleName) {
+        return new AssumeRoleRequest()
+                .withRoleArn(toRoleArn(accountID, roleName))
+                .withRoleSessionName(ROLE_SESSION_NAME_PREFIX + new Date().getTime());
+    }
+
+    /**
      * Generates tenant email string using tenant name.
      *  example email address: tenant.name@osis.scality.com
      *
@@ -107,6 +121,20 @@ public final class ScalityModelConverter {
     public static Map<String,String> toScalityCustomAttributes(List<String> cdTenantIds) {
         return cdTenantIds.stream()
                 .collect(Collectors.toMap(str-> CD_TENANT_ID_PREFIX + str, str -> ""));
+    }
+
+    /**
+     * Converts account ID to Vault super role arn
+     *
+     * @param accountID account id
+     * @param roleName role name
+     * @return the role arn.
+     *          Example: <code>arn:aws:iam::[account-id]:role/[role-name]</code>
+     */
+    private static String toRoleArn(String accountID, String roleName) {
+        return ROLE_ARN_FORMAT
+                .replace(ACCOUNT_ID_REGEX, accountID)
+                .replace(ROLE_NAME_REGEX, roleName);
     }
 
     /* Converter methods below will convert Vault/Scality responses to OSIS model objects @param accountResponse the account response */

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
@@ -1,5 +1,6 @@
 package com.scality.osis.utils;
 
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.vmware.osis.model.OsisTenant;
 import com.vmware.osis.model.exception.BadRequestException;
 import com.scality.vaultclient.dto.Account;
@@ -90,5 +91,15 @@ public class ScalityModelConverterTest {
                 SAMPLE_CD_TENANT_IDS.containsAll(osisTenant.getCdTenantIds())
                 && osisTenant.getCdTenantIds().containsAll(SAMPLE_CD_TENANT_IDS), "failed createAccountResponseToOsisTenantTest:getCdTenantIds()");
         assertTrue(osisTenant.getActive(), "failed createAccountResponseToOsisTenantTest:getActive()");
+    }
+
+    @Test
+    public void  testGetAssumeRoleRequestForAccount() {
+
+
+        final AssumeRoleRequest assumeRoleRequest = ScalityModelConverter.getAssumeRoleRequestForAccount(SAMPLE_TENANT_ID, SAMPLE_ASSUME_ROLE_NAME);
+
+        assertEquals(TEST_ROLE_ARN, assumeRoleRequest.getRoleArn(), "failed  testGetAssumeRoleRequestForAccount:getRoleArn()");
+        assertTrue(assumeRoleRequest.getRoleSessionName().startsWith(TEST_SESSION_NAME_PREFIX), "failed  testGetAssumeRoleRequestForAccount:getRoleSessionName()");
     }
 }

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 public final class ScalityTestUtils {
 
-    public static final String SAMPLE_TENANT_ID = "12313265465789";
+    public static final String SAMPLE_TENANT_ID = "123123123123";
     public static final String SAMPLE_ID = "bfc0d4a51e06481cbc917e9d96e52d81";
     public static final String SAMPLE_TENANT_NAME = "tenant name";
     public static final List<String> SAMPLE_CD_TENANT_IDS = new ArrayList<>(
@@ -20,6 +20,9 @@ public final class ScalityTestUtils {
                     "5b7e3259-aace-414c-bfd8-94daa0efefaf","6b7e3259-aace-414c-bfd8-94daa0efefaf",
                     "4b7e3259-aace-414c-bfd8-94daa0efefaf","3b7e3259-aace-414c-bfd8-94daa0efefaf")
     );
+    public static final String TEST_ROLE_ARN = "arn:aws:iam::123123123123:role/osis";
+    public static final String TEST_SESSION_NAME_PREFIX = "ROLE_SESSION_";
+    public static final String SAMPLE_ASSUME_ROLE_NAME ="osis";
 
     public static final Map<String, String> SAMPLE_CUSTOM_ATTRIBUTES  = new HashMap<>() ;
     static {
@@ -35,7 +38,22 @@ public final class ScalityTestUtils {
 
     public static final String SAMPLE_SCALITY_ACCOUNT_EMAIL = "tenant.name@osis.scality.com";
 
-    public static final String SAMPLE_SCALITY_ACCOUNT_NAME ="tenant.name";
+
+    public static final String TEST_TENANT_ID ="tenantId";
+    public static final String TEST_STR ="value";
+    public static final String NOT_IMPLEMENTED_EXCEPTION_ERR ="expected NotImplementedException";
+    public static final String NULL_ERR ="Expected Value. Found Null";
+    public static final String INVALID_URL_URL ="Invalid URL";
+    public static final String TEST_USER_ID ="userId";
+    public static final String TEST_NAME ="name";
+    public static final String TEST_ACCESS_KEY = "access_key";
+    public static final String TEST_SECRET_KEY = "secret_key";
+    public static final String TEST_SESSION_TOKEN = "session_token";
+    public static final String TEST_CONSOLE_URL ="https://example.console.ose.scality.com";
+    public static final String TEST_S3_INTERFACE_URL ="https://localhost:8443";
+    public static final String PLATFORM_NAME ="Scality";
+    public static final String PLATFORM_VERSION ="7.10";
+    public static final String API_VERSION ="1.0.0";
 
 
     private ScalityTestUtils(){


### PR DESCRIPTION
Implemented `getCredentials` on `ScalityOsisService.java` to be used by all OSIS IAM flows. This method
* transforms `accountID` and prepares `AssumeRoleRequest`
* calls Vault with prepared `AssumeRoleRequest`