### PR TITLE
feature:S3C-3532 Create user Implementation

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisService.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisService.java
@@ -6,6 +6,8 @@
 
 package com.scality.osis.service.impl;
 
+import com.amazonaws.services.identitymanagement.*;
+import com.amazonaws.services.identitymanagement.model.*;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import com.amazonaws.util.StringUtils;
 import com.scality.osis.ScalityAppEnv;
@@ -34,6 +36,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
 
 import static com.scality.osis.utils.ScalityConstants.CD_TENANT_ID_PREFIX;
@@ -170,7 +173,56 @@ public class ScalityOsisService implements OsisService {
 
     @Override
     public OsisUser createUser(OsisUser osisUser) {
-        throw new NotImplementedException();
+        try {
+            logger.info("Create User request received:{}", new Gson().toJson(osisUser));
+
+            Credentials tempCredentials = getCredentials(osisUser.getTenantId());
+            final AmazonIdentityManagement iam = vaultAdmin.getIAMClient(tempCredentials, appEnv.getRegionInfo().get(0));
+
+            CreateUserRequest createUserRequest =  ScalityModelConverter.toCreateUserRequest(osisUser);
+            logger.debug("[Vault] Create User Request:{}", new Gson().toJson(createUserRequest));
+
+            CreateUserResult createUserResult = iam.createUser(createUserRequest);
+
+            logger.debug("[Vault] Create User response:{}", new Gson().toJson(createUserResult));
+
+            OsisUser resOsisUser = null;
+
+            if( null != createUserResult) {
+
+                resOsisUser = ScalityModelConverter.toOsisUser(createUserResult, osisUser.getTenantId());
+
+                /** Get userpolicy@<Account_id> **/
+                Policy userPolicy = getOrCreateUserPolicy(iam, resOsisUser.getTenantId());
+
+                /** Attach user policy to the user **/
+                AttachUserPolicyRequest attachUserPolicyRequest = ScalityModelConverter.toAttachUserPolicyRequest(userPolicy.getArn(), resOsisUser.getUserId());
+                logger.debug("[Vault] Attach User Policy Request:{}", new Gson().toJson(attachUserPolicyRequest));
+
+                AttachUserPolicyResult attachUserPolicyResult = iam.attachUserPolicy(attachUserPolicyRequest);
+                logger.debug("[Vault] Attach User Policy response:{}", new Gson().toJson(attachUserPolicyResult));
+
+                /** Create User Access Key for the user **/
+                OsisS3Credential osisCredential = createOsisCredential(
+                        resOsisUser.getTenantId(),
+                        resOsisUser.getUserId(),
+                        resOsisUser.getCdTenantId(),
+                        resOsisUser.getUsername(),
+                        iam);
+
+                resOsisUser.setOsisS3Credentials(Arrays.asList(osisCredential));
+
+                logger.info("Create User response:{}", new Gson().toJson(resOsisUser));
+            }
+
+            return resOsisUser;
+
+        } catch (Exception e){
+            // Create User supports only 400:BAD_REQUEST error, change status code in the VaultServiceException
+            logger.error("Create User error. Error details: ", e);
+            throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+        }
+
     }
 
     @Override
@@ -328,5 +380,54 @@ public class ScalityOsisService implements OsisService {
             throw e;
         }
         return credentials;
+    }
+
+    public OsisS3Credential createOsisCredential(String tenantId, String userId, String cdTenantId, String username, AmazonIdentityManagement iam) {
+
+        CreateAccessKeyRequest createAccessKeyRequest =  ScalityModelConverter.toCreateUserAccessKeyRequest(userId);
+
+        logger.debug("[Vault] Create User Access Key Request:{}", new Gson().toJson(createAccessKeyRequest));
+
+        CreateAccessKeyResult createAccessKeyResult = iam.createAccessKey(createAccessKeyRequest);
+
+        logger.debug("[Vault] Create User Access Key response:{}", new Gson().toJson(createAccessKeyResult));
+
+        return ScalityModelConverter.toOsisS3Credentials(cdTenantId,
+                tenantId,
+                username,
+                createAccessKeyResult);
+    }
+
+    public Policy getOrCreateUserPolicy(AmazonIdentityManagement iam, String tenantId) {
+        Policy userPolicy = null;
+
+        GetPolicyRequest getPolicyRequest = ScalityModelConverter.toGetPolicyRequest(tenantId);
+
+        logger.debug("[Vault] Get Policy Request:{}", new Gson().toJson(getPolicyRequest));
+
+        try {
+            GetPolicyResult getPolicyResult = iam.getPolicy(getPolicyRequest);
+
+            logger.debug("[Vault] Get Policy response:{}", new Gson().toJson(getPolicyResult));
+
+            userPolicy = getPolicyResult.getPolicy();
+
+        } catch(com.amazonaws.services.identitymanagement.model.NoSuchEntityException e){
+            /** Policy does not exists **/
+            logger.debug("[Vault] User policy does not exists.", e);
+        }
+
+        if(userPolicy == null || StringUtils.isNullOrEmpty(userPolicy.getArn())){
+            /** Create a new policy with necessary permissions **/
+            CreatePolicyRequest createPolicyRequest = ScalityModelConverter.toCreateUserPolicyRequest(tenantId);
+            logger.debug("[Vault] Create Policy Request:{}", new Gson().toJson(createPolicyRequest));
+
+            CreatePolicyResult createPolicyResult = iam.createPolicy(createPolicyRequest);
+            logger.debug("[Vault] Create Policy response:{}", new Gson().toJson(createPolicyResult));
+
+            userPolicy = createPolicyResult.getPolicy();
+
+        }
+        return userPolicy;
     }
 }

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -37,26 +37,26 @@ public final class ScalityConstants {
     public static final String DEFAULT_ADMIN_POLICY_DESCRIPTION = "This is a admin role policy created for OSIS to IAM actions using AssumeRole for the $ACCOUNTID account";
 
     public static final String DEFAULT_OSIS_ROLE_INLINE_POLICY = "{\n" +
-                                                                    "        \"Version\": \"2012-10-17\",\n" +
-                                                                    "        \"Statement\": [{\n" +
-                                                                    "                \"Effect\": \"Allow\",\n" +
-                                                                    "                \"Principal\": \"*\",\n" +
-                                                                    "                \"Action\": \"sts:AssumeRole\"\n" +
-                                                                    "        }]\n" +
-                                                                    "}";
+            "        \"Version\": \"2012-10-17\",\n" +
+            "        \"Statement\": [{\n" +
+            "                \"Effect\": \"Allow\",\n" +
+            "                \"Principal\": \"*\",\n" +
+            "                \"Action\": \"sts:AssumeRole\"\n" +
+            "        }]\n" +
+            "}";
 
     public static final String DEFAULT_ADMIN_POLICY_DOCUMENT  = "{\n" +
-                                                                "   \"Version\":\"2012-10-17\",\n" +
-                                                                "   \"Statement\":[\n" +
-                                                                "      {\n" +
-                                                                "         \"Effect\":\"Allow\",\n" +
-                                                                "         \"Action\":[\n" +
-                                                                "            \"iam:*\"\n" +
-                                                                "         ],\n" +
-                                                                "         \"Resource\":\"*\"\n" +
-                                                                "      }\n" +
-                                                                "   ]\n" +
-                                                                "}";
+            "   \"Version\":\"2012-10-17\",\n" +
+            "   \"Statement\":[\n" +
+            "      {\n" +
+            "         \"Effect\":\"Allow\",\n" +
+            "         \"Action\":[\n" +
+            "            \"iam:*\"\n" +
+            "         ],\n" +
+            "         \"Resource\":\"*\"\n" +
+            "      }\n" +
+            "   ]\n" +
+            "}";
 
     public static final String ACCOUNT_ADMIN_POLICY_ARN_REGEX = "arn:aws:iam::$ACCOUNTID:policy/adminPolicy@$ACCOUNTID";
 
@@ -67,4 +67,20 @@ public final class ScalityConstants {
     public static final String DEFAULT_ASYNC_EXECUTOR_CORE_POOL_SIZE = "10";
     public static final String DEFAULT_ASYNC_EXECUTOR_MAX_POOL_SIZE = "10";
     public static final String DEFAULT_ASYNC_EXECUTOR_QUEUE_CAPACITY = "500";
+
+    public static final String USER_POLICY_ARN_REGEX = "arn:aws:iam::$ACCOUNTID:policy/userPolicy@$ACCOUNTID";
+
+    public static final String USER_POLICY_NAME_REGEX = "userPolicy@$ACCOUNTID";
+
+    public static final String DEFAULT_USER_POLICY_DESCRIPTION = "This is a common user policy created by OSIS for all the users belonging to the $ACCOUNTID account";
+
+    public static final String DEFAULT_USER_POLICY_DOCUMENT = "{\n  " +
+                                                        "\"Version\": \"2012-10-17\",\n  " +
+                                                        "\"Statement\": [\n    {\n      " +
+                                                                                    "\"Effect\": \"Allow\",\n      " +
+                                                                                    "\"Action\": [\n        " +
+                                                                                        "\"s3:*\",\n        " +
+                                                                                        "\"kms:*\"\n      ],\n      " +
+                                                                                    "\"Resource\": \"*\"\n    }\n  " +
+                                                                        "]\n}";
 }

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTest.java
@@ -81,6 +81,9 @@ public class ScalityOsisServiceTest {
         initAttachRolePolicyMocks();
         initDeleteAccessKeyMocks();
         initGetAccountMocks();
+        initGetPolicyMocks();
+        initCreateAccessRequestMocks();
+        initCreateUserMocks();
         initCaches();
     }
 
@@ -249,6 +252,49 @@ public class ScalityOsisServiceTest {
                 });
     }
 
+    private void initCreateUserMocks() {
+
+        when(iamMock.createUser(any(CreateUserRequest.class)))
+                .thenAnswer((Answer<CreateUserResult>) invocation -> {
+                    final CreateUserRequest request = invocation.getArgument(0);
+                    final User user = new User()
+                            .withUserId(TEST_USER_ID)
+                            .withUserName(request.getUserName())
+                            .withPath(request.getPath())
+                            .withCreateDate(new Date());
+                    final CreateUserResult response = new CreateUserResult()
+                            .withUser(user);
+                    return response;
+                });
+    }
+
+    private void initGetPolicyMocks() {
+        when(iamMock.getPolicy(any(GetPolicyRequest.class)))
+                .thenAnswer((Answer<GetPolicyResult>) invocation -> {
+                    final GetPolicyRequest request = invocation.getArgument(0);
+                    final GetPolicyResult response = new GetPolicyResult();
+                    final Policy policy = new Policy()
+                            .withArn(request.getPolicyArn());
+                    response.setPolicy(policy);
+                    return response;
+                });
+    }
+
+    private void initCreateAccessRequestMocks() {
+        when(iamMock.createAccessKey(any(CreateAccessKeyRequest.class)))
+                .thenAnswer((Answer<CreateAccessKeyResult>) invocation -> {
+                    final CreateAccessKeyRequest request = invocation.getArgument(0);
+                    final AccessKey accessKeyObj = new AccessKey()
+                            .withAccessKeyId(TEST_ACCESS_KEY)
+                            .withSecretAccessKey(TEST_SECRET_KEY)
+                            .withCreateDate(new Date())
+                            .withUserName(request.getUserName());
+                    final CreateAccessKeyResult response = new CreateAccessKeyResult()
+                            .withAccessKey(accessKeyObj);
+                    return response;
+                });
+    }
+
     private void initCaches() {
         final CacheFactory cacheFactoryMock = mock(CacheFactory.class);
         when(cacheFactoryMock.getCache(NAME_LIST_ACCOUNTS_CACHE)).thenReturn(new CacheImpl<>(DEFAULT_CACHE_MAX_CAPACITY));
@@ -309,8 +355,6 @@ public class ScalityOsisServiceTest {
             scalityOsisServiceUnderTest.createTenant(createSampleOsisTenantObj());
         });
 
-        //resetting mocks to original
-        initMocks();
     }
 
     @Test
@@ -451,21 +495,47 @@ public class ScalityOsisServiceTest {
     public void testCreateUser() {
         // Setup
         final OsisUser osisUser = new OsisUser();
-        osisUser.userId(TEST_USER_ID);
         osisUser.setUserId(TEST_USER_ID);
-        osisUser.canonicalUserId("canonicalUserId");
-        osisUser.setCanonicalUserId("canonicalUserId");
-        osisUser.tenantId(TEST_TENANT_ID);
+        osisUser.setCanonicalUserId(TEST_USER_ID);
         osisUser.setTenantId(TEST_TENANT_ID);
-        osisUser.active(false);
-        osisUser.setActive(false);
-        osisUser.cdUserId("cdUserId");
-        osisUser.setCdUserId("cdUserId");
+        osisUser.setCdTenantId(TEST_TENANT_ID);
+        osisUser.setActive(true);
+        osisUser.setCdUserId(TEST_USER_ID);
+        osisUser.setRole(OsisUser.RoleEnum.TENANT_USER);
+        osisUser.setUsername(TEST_NAME);
 
         // Run the test
-        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.createUser(osisUser), NOT_IMPLEMENTED_EXCEPTION_ERR);
+        final OsisUser result = scalityOsisServiceUnderTest.createUser(osisUser);
 
         // Verify the results
+        assertEquals(TEST_USER_ID, result.getCdUserId());
+        assertEquals(TEST_USER_ID, result.getUserId());
+        assertEquals(TEST_NAME, result.getUsername());
+        assertEquals(TEST_TENANT_ID, result.getCdTenantId());
+        assertEquals(TEST_TENANT_ID, result.getTenantId());
+        assertEquals(TEST_NAME, result.getOsisS3Credentials().get(0).getUsername(), "Invalid getOsisS3Credentials username");
+        assertEquals(TEST_USER_ID, result.getOsisS3Credentials().get(0).getUserId(), "Invalid getOsisS3Credentials getUserId");
+        assertEquals(TEST_USER_ID, result.getOsisS3Credentials().get(0).getCdUserId(), "Invalid getOsisS3Credentials getCdUserId");
+        assertEquals(TEST_SECRET_KEY, result.getOsisS3Credentials().get(0).getSecretKey(), "Invalid getOsisS3Credentials getSecretKey");
+        assertEquals(TEST_ACCESS_KEY, result.getOsisS3Credentials().get(0).getAccessKey(), "Invalid getOsisS3Credentials getAccessKey");
+        assertEquals(TEST_TENANT_ID, result.getOsisS3Credentials().get(0).getTenantId(), "Invalid getOsisS3Credentials getTenantId");
+        assertEquals(TEST_TENANT_ID, result.getOsisS3Credentials().get(0).getCdTenantId(), "Invalid getOsisS3Credentials getCdTenantId");
+        assertTrue(result.getActive());
+    }
+
+    @Test
+    public void testCreateUser400() {
+        // Setup
+        when(iamMock.createUser(any(CreateUserRequest.class)))
+                .thenAnswer((Answer<CreateUserResult>) invocation -> {
+                    throw new VaultServiceException(HttpStatus.BAD_REQUEST, "Bad Request");
+                });
+
+        // Run the test
+        // Verify the results
+        assertThrows(VaultServiceException.class, () -> {
+            scalityOsisServiceUnderTest.createUser(new OsisUser());
+        });
     }
 
     @Test
@@ -808,18 +878,6 @@ public class ScalityOsisServiceTest {
     }
 
     @Test
-    public void testGetCredentialsWithNoRoleFail() {
-        // Setup
-
-        when(vaultAdminMock.getTempAccountCredentials(any(AssumeRoleRequest.class)))
-                .thenThrow(new VaultServiceException(HttpStatus.NOT_FOUND, "NoSuchEntity", "Role does not exist"))
-                .thenThrow(new VaultServiceException(HttpStatus.NOT_FOUND, "MalformedPolicyDocument"));
-        // Run the test
-        // Verify the results
-        assertThrows(VaultServiceException.class, () -> scalityOsisServiceUnderTest.getCredentials(TEST_TENANT_ID));
-    }
-
-    @Test
     public void testGetCredentials400() {
         // Setup
         when(vaultAdminMock.getTempAccountCredentials(any(AssumeRoleRequest.class)))
@@ -906,6 +964,50 @@ public class ScalityOsisServiceTest {
         verify(iamMock).createPolicy(any(CreatePolicyRequest.class));
         verify(iamMock).attachRolePolicy(any(AttachRolePolicyRequest.class));
         verify(iamMock, never()).deleteAccessKey(any(DeleteAccessKeyRequest.class));
+    }
+
+    @Test
+    public void testGetOrCreateUserPolicy1() {
+        // Setup
+        // Run the test
+        final Policy policy = scalityOsisServiceUnderTest.getOrCreateUserPolicy(iamMock, TEST_TENANT_ID);
+
+        // Verify the results
+        assertEquals("arn:aws:iam::" + TEST_TENANT_ID +":policy/userPolicy@" + TEST_TENANT_ID, policy.getArn(), "Invalid Policy arn");
+    }
+
+    @Test
+    public void testGetOrCreateUserPolicy2() {
+        // Setup
+        // Modify get policy to return no entity found
+        when(iamMock.getPolicy(any()))
+                .thenAnswer((Answer<GetPolicyResult>) invocation -> {
+                    throw new NoSuchEntityException("Entity does not exist");
+                });
+        // Run the test
+        final Policy policy = scalityOsisServiceUnderTest.getOrCreateUserPolicy(iamMock, TEST_TENANT_ID);
+
+        // Verify the results
+        assertEquals("arn:aws:iam::" + TEST_TENANT_ID +":policy/userPolicy@" + TEST_TENANT_ID, policy.getArn(), "Invalid Policy arn");
+        assertEquals("userPolicy@" + TEST_TENANT_ID, policy.getPolicyName(), "Invalid Policy name");
+    }
+
+    @Test
+    public void testCreateOsisCredential() {
+        // Setup
+        // Modify get policy to return no entity found
+
+        // Run the test
+        final OsisS3Credential osisCredential = scalityOsisServiceUnderTest.createOsisCredential(TEST_TENANT_ID, TEST_USER_ID, TEST_TENANT_ID, TEST_NAME, iamMock);
+
+        // Verify the results
+        assertEquals(TEST_NAME, osisCredential.getUsername(), "Invalid username");
+        assertEquals(TEST_USER_ID, osisCredential.getUserId(), "Invalid getUserId");
+        assertEquals(TEST_USER_ID, osisCredential.getCdUserId(), "Invalid getCdUserId");
+        assertEquals(TEST_SECRET_KEY, osisCredential.getSecretKey(), "Invalid getSecretKey");
+        assertEquals(TEST_ACCESS_KEY, osisCredential.getAccessKey(), "Invalid getAccessKey");
+        assertEquals(TEST_TENANT_ID, osisCredential.getTenantId(), "Invalid getTenantId");
+        assertEquals(TEST_TENANT_ID, osisCredential.getCdTenantId(), "Invalid getCdTenantId");
     }
 
 

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
@@ -37,6 +37,7 @@ public final class ScalityTestUtils {
 
 
     public static final String SAMPLE_SCALITY_ACCOUNT_EMAIL = "tenant.name@osis.scality.com";
+    public static final String SAMPLE_SCALITY_USER_EMAIL = "user.name@osis.scality.com";
 
 
     public static final String TEST_TENANT_ID ="tenantId";
@@ -46,6 +47,7 @@ public final class ScalityTestUtils {
     public static final String INVALID_URL_URL ="Invalid URL";
     public static final String TEST_USER_ID ="userId";
     public static final String TEST_NAME ="name";
+    public static final String TEST_POLICY_ARN ="policy-arn";
     public static final String TEST_ACCESS_KEY = "access_key";
     public static final String TEST_SECRET_KEY = "secret_key";
     public static final String TEST_SESSION_TOKEN = "session_token";
@@ -55,7 +57,6 @@ public final class ScalityTestUtils {
     public static final String PLATFORM_VERSION ="7.10";
     public static final String API_VERSION ="1.0.0";
     public static final long SAMPLE_DURATION_SECONDS = 120L;
-    public static final String TEST_POLICY_ARN ="policy-arn";
     public static final String ACTIVE_STR = "Active";
     public static final String NA_STR = "N/A";
 


### PR DESCRIPTION
* Implement Create User w/ all IAM APIs
  * Call AssumeRoleBackbeat to get temporary credentials
  * Call IAM Create User
  * Call IAM Get User Policy if exists
  * If Policy does not exist, Create User Policy
  * Create Access key for the user
 * Implemented Create User Test cases