### PR TITLE
feature:S3C-4094 create tenant generateAccountAccessKey()

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/ScalityAppEnv.java
+++ b/osis-core/src/main/java/com/scality/osis/ScalityAppEnv.java
@@ -18,6 +18,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.scality.osis.utils.ScalityConstants.DEFAULT_ACCOUNT_AK_DURATION_SECONDS;
+
 @Component
 @Primary
 public class ScalityAppEnv extends AppEnv {
@@ -98,5 +100,13 @@ public class ScalityAppEnv extends AppEnv {
 
     public String getAssumeRoleName() {
         return env.getProperty("osis.scality.vault.role.name");
+    }
+
+    public long getAccountAKDurationSeconds() {
+        String durationSeconds =  env.getProperty("osis.scality.vault.account.accessKey.durationSeconds");
+        if(StringUtils.isBlank(durationSeconds)) {
+            durationSeconds = DEFAULT_ACCOUNT_AK_DURATION_SECONDS;
+        }
+        return Long.parseLong(durationSeconds);
     }
 }

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -27,4 +27,6 @@ public final class ScalityConstants {
     public static final String ICON_PATH = "/scalitylogo.png";
 
     public static final String IAM_PREFIX = "/";
+
+    public static final String DEFAULT_ACCOUNT_AK_DURATION_SECONDS = "120";
 }

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -6,6 +6,7 @@
 package com.scality.osis.utils;
 
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
+import com.scality.vaultclient.dto.GenerateAccountAccessKeyRequest;
 import com.scality.vaultclient.dto.ListAccountsRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsResponseDTO;
 import com.vmware.osis.model.OsisTenant;
@@ -97,6 +98,21 @@ public final class ScalityModelConverter {
         return new AssumeRoleRequest()
                 .withRoleArn(toRoleArn(accountID, roleName))
                 .withRoleSessionName(ROLE_SESSION_NAME_PREFIX + new Date().getTime());
+    }
+
+    /**
+     * Creates GenerateAccountAccessKeyRequest dto for given account id and duration in seconds
+     * @param accountID the account ID
+     * @param durationSeconds the duration in seconds
+     *
+     * @return the GenerateAccountAccessKeyRequest dto
+     */
+    public static GenerateAccountAccessKeyRequest toGenerateAccountAccessKeyRequest(String accountID,
+                                                                                    long durationSeconds) {
+        return GenerateAccountAccessKeyRequest.builder()
+                .accountName(accountID)
+                .durationSeconds(durationSeconds)
+                .build();
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,9 @@ osis.scality.version=15.2.3
 # Vault common role name for Assume Role backbeat
 osis.scality.vault.role.name=osis
 
+# Vault access key duration in seconds for account
+osis.scality.vault.account.accessKey.durationSeconds=120
+
 # Vault Config - Vault endpoint and admin port with super admin credentials
 osis.scality.vault.endpoint=http://localhost:8600
 osis.scality.vault.access-key=D4IT2AWSB588GO5J9T00

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/VaultAdmin.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/VaultAdmin.java
@@ -10,6 +10,8 @@ import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import com.scality.vaultclient.dto.CreateAccountRequestDTO;
 import com.scality.vaultclient.dto.CreateAccountResponseDTO;
+import com.scality.vaultclient.dto.GenerateAccountAccessKeyRequest;
+import com.scality.vaultclient.dto.GenerateAccountAccessKeyResponse;
 import com.scality.vaultclient.dto.ListAccountsRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsResponseDTO;
 import com.scality.vaultclient.services.AccountServicesClient;
@@ -75,6 +77,21 @@ public interface VaultAdmin {
    */
   Credentials getTempAccountCredentials(AssumeRoleRequest assumeRoleRequest);
 
+  /**
+   * Returns the temporary account credentials
+   *
+   * @param credentials the credential object with AK/SK and @optional `SessionToken`
+   * @param region the region
+   * @return the iam client with requested credentials, vault end point and region
+   */
   AmazonIdentityManagement getIAMClient(Credentials credentials, String region);
+
+  /**
+   * Returns the temporary account credentials
+   *
+   * @param generateAccountAccessKeyRequest Generate Account Access Key Request
+   * @return GenerateAccountAccessKeyResponse with AK/SK for the account
+   */
+  GenerateAccountAccessKeyResponse getAccountAccessKey(GenerateAccountAccessKeyRequest generateAccountAccessKeyRequest);
 
 }

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/VaultAdminImpl.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/VaultAdminImpl.java
@@ -19,6 +19,8 @@ import com.scality.osis.vaultadmin.impl.cache.CacheFactory;
 import com.scality.vaultclient.dto.AssumeRoleResult;
 import com.scality.vaultclient.dto.CreateAccountRequestDTO;
 import com.scality.vaultclient.dto.CreateAccountResponseDTO;
+import com.scality.vaultclient.dto.GenerateAccountAccessKeyRequest;
+import com.scality.vaultclient.dto.GenerateAccountAccessKeyResponse;
 import com.scality.vaultclient.dto.ListAccountsRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsResponseDTO;
 import com.scality.vaultclient.services.AccountServicesClient;
@@ -69,7 +71,7 @@ public class VaultAdminImpl implements VaultAdmin{
    * @param s3InterfaceEndpoint Vault S3 Interface endpoint, e.g., http://127.0.0.1:8500
    */
   @Autowired
-  public VaultAdminImpl(@Value("${osis.scality.vault.access-key}") String accessKey, @Value("${osis.scality.vault.secret-key}") String secretKey, @Value("${osis.scality.vault.endpoint}") String vaultAdminEndpoint, @Value("${osis.scality.s3.endpoint}") String s3InterfaceEndpoint) {
+  public VaultAdminImpl(@Value("${osis.scality.vault.access-key}") String accessKey, @Value("${osis.scality.vault.secret-key}") String secretKey, @Value("${osis.scality.vault.endpoint}") String vaultAdminEndpoint, @Value("${osis.scality.vaultS3Interface.endpoint}") String s3InterfaceEndpoint) {
     validEndpoint(vaultAdminEndpoint);
     this.vaultAdminEndpoint = vaultAdminEndpoint;
     this.vaultAccountClient = new AccountServicesClient(
@@ -291,5 +293,16 @@ public class VaultAdminImpl implements VaultAdmin{
               .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(vaultAdminEndpoint, region))
               .build();
     }
+  }
+
+  /**
+   * Returns the temporary account credentials
+   *
+   * @param generateAccountAccessKeyRequest Generate Account Access Key Request
+   * @return GenerateAccountAccessKeyResponse with AK/SK for the account
+   */
+  @Override
+  public GenerateAccountAccessKeyResponse getAccountAccessKey(GenerateAccountAccessKeyRequest generateAccountAccessKeyRequest) {
+    return ExternalServiceFactory.executeVaultService(vaultAccountClient::generateAccountAccessKey, generateAccountAccessKeyRequest);
   }
 }

--- a/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/VaultAdminImplTest.java
+++ b/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/VaultAdminImplTest.java
@@ -7,11 +7,7 @@ import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import com.scality.osis.vaultadmin.impl.cache.CacheFactory;
 import com.scality.osis.vaultadmin.impl.cache.CacheImpl;
-import com.scality.vaultclient.dto.AssumeRoleResult;
-import com.scality.vaultclient.dto.CreateAccountRequestDTO;
-import com.scality.vaultclient.dto.CreateAccountResponseDTO;
-import com.scality.vaultclient.dto.ListAccountsRequestDTO;
-import com.scality.vaultclient.dto.ListAccountsResponseDTO;
+import com.scality.vaultclient.dto.*;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import java.io.IOException;
@@ -22,12 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static com.scality.osis.vaultadmin.impl.cache.CacheConstants.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -207,6 +198,25 @@ public class VaultAdminImplTest extends BaseTest {
 
         //reinit the default mocks
         initMocks();
+    }
+
+    @Test
+    public void testGetAccountAccessKey() {
+
+        final GenerateAccountAccessKeyRequest generateAccountAccessKeyRequest = GenerateAccountAccessKeyRequest.builder()
+                .accountName(DEFAULT_TEST_ACCOUNT_ID)
+                .durationSeconds(60L)
+                .build();
+
+        final GenerateAccountAccessKeyResponse response = vaultAdminImpl.getAccountAccessKey(generateAccountAccessKeyRequest);
+        assertNotNull(response.getData());
+        final AccountSecretKeyData secretKeyData = response.getData();
+        assertNotNull(secretKeyData.getId());
+        assertNotNull(secretKeyData.getValue());
+        assertNotNull(secretKeyData.getNotAfter());
+        assertEquals(ACTIVE_STR, secretKeyData.getStatus());
+        assertNotNull(secretKeyData.getCreateDate());
+        assertNotNull(secretKeyData.getLastUsedDate());
     }
 
     @Test


### PR DESCRIPTION
Integrated Vault generateAccountAccessKey() during OSIS create Tenant to start the `Setup AssumeRole` subroutine 