### PR TITLE
feature:S3C-4094 Implement setupAssumeRole subroutine

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/ScalityAppEnv.java
+++ b/osis-core/src/main/java/com/scality/osis/ScalityAppEnv.java
@@ -19,6 +19,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.scality.osis.utils.ScalityConstants.DEFAULT_ACCOUNT_AK_DURATION_SECONDS;
+import static com.scality.osis.utils.ScalityConstants.DEFAULT_ASYNC_EXECUTOR_CORE_POOL_SIZE;
+import static com.scality.osis.utils.ScalityConstants.DEFAULT_ASYNC_EXECUTOR_MAX_POOL_SIZE;
+import static com.scality.osis.utils.ScalityConstants.DEFAULT_ASYNC_EXECUTOR_QUEUE_CAPACITY;
 
 @Component
 @Primary
@@ -108,5 +111,29 @@ public class ScalityAppEnv extends AppEnv {
             durationSeconds = DEFAULT_ACCOUNT_AK_DURATION_SECONDS;
         }
         return Long.parseLong(durationSeconds);
+    }
+
+    public int getAsyncExecutorCorePoolSize() {
+        String asyncExecutorCorePoolSize =  env.getProperty("osis.scality.async.corePoolSize");
+        if(StringUtils.isBlank(asyncExecutorCorePoolSize)) {
+            asyncExecutorCorePoolSize = DEFAULT_ASYNC_EXECUTOR_CORE_POOL_SIZE;
+        }
+        return Integer.parseInt(asyncExecutorCorePoolSize);
+    }
+
+    public int getAsyncExecutorMaxPoolSize() {
+        String asyncExecutorMaxPoolSize =  env.getProperty("osis.scality.async.maxPoolSize");
+        if(StringUtils.isBlank(asyncExecutorMaxPoolSize)) {
+            asyncExecutorMaxPoolSize = DEFAULT_ASYNC_EXECUTOR_MAX_POOL_SIZE;
+        }
+        return Integer.parseInt(asyncExecutorMaxPoolSize);
+    }
+
+    public int getAsyncExecutorQueueCapacity() {
+        String asyncExecutorQueueCapacity =  env.getProperty("osis.scality.async.queueCapacity");
+        if(StringUtils.isBlank(asyncExecutorQueueCapacity)) {
+            asyncExecutorQueueCapacity = DEFAULT_ASYNC_EXECUTOR_QUEUE_CAPACITY;
+        }
+        return Integer.parseInt(asyncExecutorQueueCapacity);
     }
 }

--- a/osis-core/src/main/java/com/scality/osis/ScalityAppEnv.java
+++ b/osis-core/src/main/java/com/scality/osis/ScalityAppEnv.java
@@ -60,7 +60,7 @@ public class ScalityAppEnv extends AppEnv {
     public List<String> getRegionInfo() {
         String regionInfo =  env.getProperty("osis.scality.region");
         if(StringUtils.isBlank(regionInfo)) {
-            return Collections.singletonList("default");
+            return Collections.singletonList("us-east-1");
         }
         return Arrays.stream(StringUtils.split(regionInfo, COMMA))
                 .map(String::trim).collect(Collectors.toList());

--- a/osis-core/src/main/java/com/scality/osis/configuration/ScalityRestConfig.java
+++ b/osis-core/src/main/java/com/scality/osis/configuration/ScalityRestConfig.java
@@ -6,13 +6,22 @@
 
 package com.scality.osis.configuration;
 
+import com.scality.osis.ScalityAppEnv;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+import static com.scality.osis.utils.ScalityConstants.ASYNC_THREADPOOL_NAME_PREFIX;
 
 @Configuration
 public class ScalityRestConfig {
+    @Autowired
+    private ScalityAppEnv env;
 
     @Bean
     public ClientHttpRequestFactory simpleClientHttpRequestFactory() {
@@ -22,4 +31,14 @@ public class ScalityRestConfig {
         return factory;
     }
 
+    @Bean
+    public Executor asyncTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(env.getAsyncExecutorCorePoolSize());
+        executor.setMaxPoolSize(env.getAsyncExecutorMaxPoolSize());
+        executor.setQueueCapacity(env.getAsyncExecutorQueueCapacity());
+        executor.setThreadNamePrefix(ASYNC_THREADPOOL_NAME_PREFIX);
+        executor.initialize();
+        return executor;
+    }
 }

--- a/osis-core/src/main/java/com/scality/osis/service/impl/AsyncScalityOsisService.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/AsyncScalityOsisService.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2021 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.service.impl;
+
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.model.AttachRolePolicyRequest;
+import com.amazonaws.services.identitymanagement.model.AttachRolePolicyResult;
+import com.amazonaws.services.identitymanagement.model.CreatePolicyRequest;
+import com.amazonaws.services.identitymanagement.model.CreatePolicyResult;
+import com.amazonaws.services.identitymanagement.model.CreateRoleRequest;
+import com.amazonaws.services.identitymanagement.model.CreateRoleResult;
+import com.amazonaws.services.identitymanagement.model.DeleteAccessKeyRequest;
+import com.amazonaws.services.identitymanagement.model.DeleteAccessKeyResult;
+import com.amazonaws.services.securitytoken.model.Credentials;
+import com.google.gson.Gson;
+import com.scality.osis.ScalityAppEnv;
+import com.scality.osis.utils.ScalityModelConverter;
+import com.scality.osis.vaultadmin.VaultAdmin;
+import com.scality.vaultclient.dto.GenerateAccountAccessKeyRequest;
+import com.scality.vaultclient.dto.GenerateAccountAccessKeyResponse;
+import com.vmware.osis.model.OsisTenant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class AsyncScalityOsisService {
+    private static final Logger logger = LoggerFactory.getLogger(AsyncScalityOsisService.class);
+
+    @Autowired
+    private ScalityAppEnv appEnv;
+
+    @Autowired
+    private VaultAdmin vaultAdmin;
+
+    @Async
+    public void setupAssumeRole(OsisTenant resOsisTenant) {
+        try {
+            logger.info(" Started [setupAssumeRole] for the Tenant:{}", resOsisTenant.getTenantId());
+
+            /* Call generateAccountAccessKey() and extract credentials from `generateAccountAccessKeyResponse`*/
+            GenerateAccountAccessKeyRequest generateAccountAccessKeyRequest =
+                    ScalityModelConverter.toGenerateAccountAccessKeyRequest(
+                            resOsisTenant.getName(),
+                            appEnv.getAccountAKDurationSeconds());
+            logger.debug("[Vault] Generate Account AccessKey Request:{}", new Gson().toJson(generateAccountAccessKeyRequest));
+
+            GenerateAccountAccessKeyResponse generateAccountAccessKeyResponse = vaultAdmin.getAccountAccessKey(generateAccountAccessKeyRequest);
+
+            logger.debug("[Vault] Generate Account AccessKey response:{}", new Gson().toJson(generateAccountAccessKeyResponse));
+
+            Credentials credentials = ScalityModelConverter.toCredentials(generateAccountAccessKeyResponse);
+
+            AmazonIdentityManagement iamClient = vaultAdmin.getIAMClient(credentials, appEnv.getRegionInfo().get(0));
+
+             /*Create OSIS admin role with sts:AssumeRole permissions*/
+            CreateRoleRequest createOSISRoleRequest = ScalityModelConverter
+                    .toCreateOSISRoleRequest(appEnv.getAssumeRoleName());
+
+            logger.debug("[Vault] Create OSIS role Request:{}", new Gson().toJson(createOSISRoleRequest));
+
+            CreateRoleResult createOSISRoleResponse = iamClient.createRole(createOSISRoleRequest);
+
+            logger.debug("[Vault] Create OSIS role response:{}", new Gson().toJson(createOSISRoleResponse));
+
+            /* Create Admin policy for account `adminPolicy@[account-id]`*/
+            CreatePolicyRequest createAdminPolicyRequest = ScalityModelConverter.toCreateAdminPolicyRequest(resOsisTenant.getTenantId());
+            logger.debug("[Vault] Create Admin Policy Request:{}", new Gson().toJson(createAdminPolicyRequest));
+
+            CreatePolicyResult adminPolicyResult = null;
+            try {
+                adminPolicyResult = iamClient.createPolicy(createAdminPolicyRequest);
+                logger.debug("[Vault] Create Admin Policy response:{}", new Gson().toJson(adminPolicyResult));
+
+            } catch (Exception e){
+                logger.error("Cannot create admin policy for Tenant ID:{}. Admin policy may already exists for this Tenant." +
+                        " Exception details:{}", resOsisTenant.getTenantId(), e.getMessage());
+            }
+             /*Attach admin policy to `osis` role*/
+            AttachRolePolicyRequest attachAdminPolicyRequest = ScalityModelConverter.
+                    toAttachAdminPolicyRequest(
+                            (adminPolicyResult != null) ?
+                                        adminPolicyResult.getPolicy().getArn() :
+                                        ScalityModelConverter.toAdminPolicyArn(resOsisTenant.getTenantId()),
+                            createOSISRoleResponse.getRole().getRoleName());
+
+            logger.debug("[Vault] Attach Admin Policy Request:{}", new Gson().toJson(attachAdminPolicyRequest));
+
+            AttachRolePolicyResult attachAdminPolicyResult = iamClient.attachRolePolicy(attachAdminPolicyRequest);
+            logger.debug("[Vault] Attach Admin Policy response:{}", new Gson().toJson(attachAdminPolicyResult));
+
+            // Delete the newly created Access Key for the account
+            DeleteAccessKeyRequest deleteAccessKeyRequest = ScalityModelConverter.
+                    toDeleteAccessKeyRequest(credentials.getAccessKeyId(), null);
+            logger.debug("[Vault] Delete Access key Request:{}", new Gson().toJson(attachAdminPolicyRequest));
+
+            DeleteAccessKeyResult deleteAccessKeyResult = iamClient.deleteAccessKey(deleteAccessKeyRequest);
+            logger.debug("[Vault] Delete Access key response:{}", new Gson().toJson(deleteAccessKeyResult));
+
+
+            logger.info(" Finished [setupAssumeRole] for the Tenant:{}", resOsisTenant.getTenantId());
+            
+        } catch (Exception e) {
+            logger.error("setupAssumeRole error for Tenant id:{}. Error details: ", resOsisTenant.getTenantId(), e);
+        }
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -29,4 +29,34 @@ public final class ScalityConstants {
     public static final String IAM_PREFIX = "/";
 
     public static final String DEFAULT_ACCOUNT_AK_DURATION_SECONDS = "120";
+
+    public static final String DEFAULT_ADMIN_POLICY_DESCRIPTION = "This is a admin role policy created for OSIS to IAM actions using AssumeRole for the $ACCOUNTID account";
+
+    public static final String DEFAULT_OSIS_ROLE_INLINE_POLICY = "{\n" +
+                                                                    "        \"Version\": \"2012-10-17\",\n" +
+                                                                    "        \"Statement\": [{\n" +
+                                                                    "                \"Effect\": \"Allow\",\n" +
+                                                                    "                \"Principal\": {\n" +
+                                                                    "                        \"Service\": \"backbeat\"\n" + // TODO: change backbeat to OSIS
+                                                                    "                },\n" +
+                                                                    "                \"Action\": \"sts:AssumeRole\"\n" +
+                                                                    "        }]\n" +
+                                                                    "}";
+
+    public static final String DEFAULT_ADMIN_POLICY_DOCUMENT  = "{\n" +
+                                                                "   \"Version\":\"2012-10-17\",\n" +
+                                                                "   \"Statement\":[\n" +
+                                                                "      {\n" +
+                                                                "         \"Effect\":\"Allow\",\n" +
+                                                                "         \"Action\":[\n" +
+                                                                "            \"iam:*\"\n" +
+                                                                "         ],\n" +
+                                                                "         \"Resource\":\"*\"\n" +
+                                                                "      }\n" +
+                                                                "   ]\n" +
+                                                                "}";
+
+    public static final String ACCOUNT_ADMIN_POLICY_ARN_REGEX = "arn:aws:iam::$ACCOUNTID:policy/adminPolicy@$ACCOUNTID";
+
+    public static final String ACCOUNT_ADMIN_POLICY_NAME_REGEX = "adminPolicy@$ACCOUNTID";
 }

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -28,6 +28,10 @@ public final class ScalityConstants {
 
     public static final String IAM_PREFIX = "/";
 
+    public static final String NO_SUCH_ENTITY_ERR = "NoSuchEntity";
+
+    public static final String ROLE_DOES_NOT_EXIST_ERR = "Role does not exist";
+
     public static final String DEFAULT_ACCOUNT_AK_DURATION_SECONDS = "120";
 
     public static final String DEFAULT_ADMIN_POLICY_DESCRIPTION = "This is a admin role policy created for OSIS to IAM actions using AssumeRole for the $ACCOUNTID account";

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -36,9 +36,7 @@ public final class ScalityConstants {
                                                                     "        \"Version\": \"2012-10-17\",\n" +
                                                                     "        \"Statement\": [{\n" +
                                                                     "                \"Effect\": \"Allow\",\n" +
-                                                                    "                \"Principal\": {\n" +
-                                                                    "                        \"Service\": \"backbeat\"\n" + // TODO: change backbeat to OSIS
-                                                                    "                },\n" +
+                                                                    "                \"Principal\": \"*\",\n" +
                                                                     "                \"Action\": \"sts:AssumeRole\"\n" +
                                                                     "        }]\n" +
                                                                     "}";
@@ -59,4 +57,10 @@ public final class ScalityConstants {
     public static final String ACCOUNT_ADMIN_POLICY_ARN_REGEX = "arn:aws:iam::$ACCOUNTID:policy/adminPolicy@$ACCOUNTID";
 
     public static final String ACCOUNT_ADMIN_POLICY_NAME_REGEX = "adminPolicy@$ACCOUNTID";
+
+    // Async threadpool executor parameters
+    public static final String ASYNC_THREADPOOL_NAME_PREFIX = "async-thread-";
+    public static final String DEFAULT_ASYNC_EXECUTOR_CORE_POOL_SIZE = "10";
+    public static final String DEFAULT_ASYNC_EXECUTOR_MAX_POOL_SIZE = "10";
+    public static final String DEFAULT_ASYNC_EXECUTOR_QUEUE_CAPACITY = "500";
 }

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -306,6 +306,7 @@ public final class ScalityModelConverter {
     public static Credentials toCredentials(GenerateAccountAccessKeyResponse generateAccountAccessKeyResponse) {
         return new Credentials()
                 .withAccessKeyId(generateAccountAccessKeyResponse.getData().getId())
-                .withSecretAccessKey(generateAccountAccessKeyResponse.getData().getValue());
+                .withSecretAccessKey(generateAccountAccessKeyResponse.getData().getValue())
+                .withExpiration(generateAccountAccessKeyResponse.getData().getNotAfter());
     }
 }

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -13,6 +13,7 @@ import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import com.scality.vaultclient.dto.GenerateAccountAccessKeyRequest;
 import com.scality.vaultclient.dto.GenerateAccountAccessKeyResponse;
+import com.scality.vaultclient.dto.GetAccountRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsResponseDTO;
 import com.vmware.osis.model.OsisTenant;
@@ -174,6 +175,18 @@ public final class ScalityModelConverter {
         }
 
         return deleteAccessKeyRequest;
+    }
+
+    /**
+     * Creates GetAccountRequestDTO
+     * @param accountID the accountID
+     *
+     * @return the GetAccountRequestDTO
+     */
+    public static GetAccountRequestDTO toGetAccountRequestWithID(String accountID) {
+        return GetAccountRequestDTO.builder()
+                .accountId(accountID)
+                .build();
     }
 
     public static String toAdminPolicyArn(String accountID) {

--- a/osis-core/src/test/java/com/scality/osis/ScalityAppEnvTest.java
+++ b/osis-core/src/test/java/com/scality/osis/ScalityAppEnvTest.java
@@ -193,7 +193,7 @@ public class ScalityAppEnvTest {
         final List<String> result = appEnvUnderTest.getRegionInfo();
 
         // Verify the results
-        assertEquals(result, Arrays.asList("default"), "testGetRegionInfoEnvironmentReturnsNull failed");
+        assertEquals(result, Arrays.asList("us-east-1"), "testGetRegionInfoEnvironmentReturnsNull failed");
     }
 
     @Test

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
@@ -1,14 +1,20 @@
 package com.scality.osis.utils;
 
+import com.amazonaws.services.identitymanagement.model.*;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
+import com.amazonaws.services.securitytoken.model.Credentials;
 import com.vmware.osis.model.OsisTenant;
 import com.vmware.osis.model.exception.BadRequestException;
 import com.scality.vaultclient.dto.Account;
 import com.scality.vaultclient.dto.AccountData;
 import com.scality.vaultclient.dto.CreateAccountRequestDTO;
 import com.scality.vaultclient.dto.CreateAccountResponseDTO;
+import com.scality.vaultclient.dto.AccountSecretKeyData;
+import com.scality.vaultclient.dto.GenerateAccountAccessKeyRequest;
+import com.scality.vaultclient.dto.GenerateAccountAccessKeyResponse;
 import org.junit.jupiter.api.Test;
 
+import java.util.Date;
 import java.util.List;
 
 import static com.scality.osis.utils.ScalityTestUtils.*;
@@ -101,5 +107,99 @@ public class ScalityModelConverterTest {
 
         assertEquals(TEST_ROLE_ARN, assumeRoleRequest.getRoleArn(), "failed  testGetAssumeRoleRequestForAccount:getRoleArn()");
         assertTrue(assumeRoleRequest.getRoleSessionName().startsWith(TEST_SESSION_NAME_PREFIX), "failed  testGetAssumeRoleRequestForAccount:getRoleSessionName()");
+    }
+
+    @Test
+    public void testToGenerateAccountAccessKeyRequest() {
+        // Setup
+        // Run the test
+        final GenerateAccountAccessKeyRequest result = ScalityModelConverter.toGenerateAccountAccessKeyRequest(SAMPLE_TENANT_NAME, SAMPLE_DURATION_SECONDS);
+
+        // Verify the results
+        assertEquals(SAMPLE_TENANT_NAME, result.getAccountName());
+        assertEquals(SAMPLE_DURATION_SECONDS, result.getDurationSeconds());
+    }
+
+    @Test
+    public void testToCreateOSISRoleRequest() {
+        // Setup
+        // Run the test
+        final CreateRoleRequest result = ScalityModelConverter.toCreateOSISRoleRequest(TEST_NAME);
+
+        // Verify the results
+        assertEquals(TEST_NAME, result.getRoleName());
+        assertNotNull(result.getAssumeRolePolicyDocument());
+    }
+
+    @Test
+    public void testToCreateAdminPolicyRequest() {
+        // Setup
+        // Run the test
+        final CreatePolicyRequest result = ScalityModelConverter.toCreateAdminPolicyRequest(TEST_TENANT_ID);
+
+        // Verify the results
+        assertTrue(result.getPolicyName().contains(TEST_TENANT_ID));
+        assertTrue(result.getDescription().contains(TEST_TENANT_ID));
+        assertNotNull(result.getPolicyDocument());
+    }
+
+    @Test
+    public void testToAttachAdminPolicyRequest() {
+        // Setup
+        // Run the test
+        final AttachRolePolicyRequest result = ScalityModelConverter.toAttachAdminPolicyRequest(TEST_POLICY_ARN, TEST_NAME);
+
+        // Verify the results
+        assertEquals(TEST_NAME, result.getRoleName());
+        assertEquals(TEST_POLICY_ARN, result.getPolicyArn());
+    }
+
+    @Test
+    public void testToDeleteAccessKeyRequest() {
+        // Setup
+        // Run the test
+        final DeleteAccessKeyRequest result = ScalityModelConverter.toDeleteAccessKeyRequest(TEST_ACCESS_KEY, TEST_NAME);
+
+        // Verify the results
+        assertEquals(TEST_NAME, result.getUserName());
+        assertEquals(TEST_ACCESS_KEY, result.getAccessKeyId());
+    }
+
+    @Test
+    public void testToAdminPolicyArn() {
+        // Setup
+        // Run the test
+        final String result = ScalityModelConverter.toAdminPolicyArn(SAMPLE_TENANT_ID);
+
+        // Verify the results
+        assertTrue(result.contains(SAMPLE_TENANT_ID));
+    }
+
+    @Test
+    public void testToCredentials() {
+        // Setup
+        final Date expirationDate = new Date(new Date().getTime() + (SAMPLE_DURATION_SECONDS * 1000L));
+        final AccountSecretKeyData accountSecretKeyData = new AccountSecretKeyData().builder()
+                .id(TEST_ACCESS_KEY)
+                .value(TEST_SECRET_KEY)
+                .userId(SAMPLE_TENANT_ID)
+                .createDate(new Date())
+                .lastUsedService(NA_STR)
+                .lastUsedRegion(NA_STR)
+                .lastUsedDate(new Date())
+                .status(ACTIVE_STR)
+                .notAfter(expirationDate)
+                .build();
+
+        final GenerateAccountAccessKeyResponse generateAccountAccessKeyResponse = new GenerateAccountAccessKeyResponse();
+        generateAccountAccessKeyResponse.setData(accountSecretKeyData);
+
+        // Run the test
+        final Credentials result = ScalityModelConverter.toCredentials(generateAccountAccessKeyResponse);
+
+        // Verify the results
+        assertEquals(TEST_ACCESS_KEY, result.getAccessKeyId());
+        assertEquals(TEST_SECRET_KEY, result.getSecretAccessKey());
+        assertEquals(expirationDate, result.getExpiration());
     }
 }

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
@@ -3,6 +3,7 @@ package com.scality.osis.utils;
 import com.amazonaws.services.identitymanagement.model.*;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.Credentials;
+import com.scality.vaultclient.dto.GetAccountRequestDTO;
 import com.vmware.osis.model.OsisTenant;
 import com.vmware.osis.model.exception.BadRequestException;
 import com.scality.vaultclient.dto.Account;
@@ -201,5 +202,19 @@ public class ScalityModelConverterTest {
         assertEquals(TEST_ACCESS_KEY, result.getAccessKeyId());
         assertEquals(TEST_SECRET_KEY, result.getSecretAccessKey());
         assertEquals(expirationDate, result.getExpiration());
+    }
+
+    @Test
+    public void testToGetAccountRequestWithID() {
+        // Setup
+        // Run the test
+        final GetAccountRequestDTO result = ScalityModelConverter.toGetAccountRequestWithID(TEST_TENANT_ID);
+
+        // Verify the results
+        assertEquals(TEST_TENANT_ID, result.getAccountId());
+        assertNull(result.getAccountName());
+        assertNull(result.getAccountArn());
+        assertNull(result.getEmailAddress());
+        assertNull(result.getCanonicalId());
     }
 }

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
@@ -54,6 +54,10 @@ public final class ScalityTestUtils {
     public static final String PLATFORM_NAME ="Scality";
     public static final String PLATFORM_VERSION ="7.10";
     public static final String API_VERSION ="1.0.0";
+    public static final long SAMPLE_DURATION_SECONDS = 120L;
+    public static final String TEST_POLICY_ARN ="policy-arn";
+    public static final String ACTIVE_STR = "Active";
+    public static final String NA_STR = "N/A";
 
 
     private ScalityTestUtils(){

--- a/pmd-rules.xml
+++ b/pmd-rules.xml
@@ -47,6 +47,7 @@ http://pmd.sourceforge.net/ruleset/2.0.0 ">
     <rule ref="category/java/design.xml">
         <exclude name="LawOfDemeter"/>
         <exclude name="TooManyMethods"/>
+        <exclude name="ExcessivePublicCount"/>
     </rule>
 
 </ruleset>

--- a/src/main/java/com/scality/osis/Application.java
+++ b/src/main/java/com/scality/osis/Application.java
@@ -9,6 +9,7 @@ package com.scality.osis;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 /**
@@ -17,6 +18,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @ComponentScan(basePackages = {"com.vmware.osis","com.scality.osis"})
 @SpringBootApplication
 @EnableSwagger2
+@EnableAsync
 public class Application {
     public static void main(String[] args) throws Exception {
         new SpringApplication(Application.class).run(args);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,3 +57,8 @@ server.ssl.enabled=true
 server.tomcat.basedir=./tomcat
 server.tomcat.accesslog.directory=logs
 server.tomcat.accesslog.enabled=true
+
+#Async Threadpool config
+osis.scality.async.maxPoolSize=10
+osis.scality.async.corePoolSize=10
+osis.scality.async.queueCapacity=500

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/VaultAdmin.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/VaultAdmin.java
@@ -8,10 +8,12 @@ package com.scality.osis.vaultadmin;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.Credentials;
+import com.scality.vaultclient.dto.AccountData;
 import com.scality.vaultclient.dto.CreateAccountRequestDTO;
 import com.scality.vaultclient.dto.CreateAccountResponseDTO;
 import com.scality.vaultclient.dto.GenerateAccountAccessKeyRequest;
 import com.scality.vaultclient.dto.GenerateAccountAccessKeyResponse;
+import com.scality.vaultclient.dto.GetAccountRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsResponseDTO;
 import com.scality.vaultclient.services.AccountServicesClient;
@@ -94,4 +96,12 @@ public interface VaultAdmin {
    */
   GenerateAccountAccessKeyResponse getAccountAccessKey(GenerateAccountAccessKeyRequest generateAccountAccessKeyRequest);
 
+  /**
+   * Get account with account id
+   * <p>This method will get the account from Vault using Account ID.
+   *
+   * @param getAccountRequestDTO the get account request dto
+   * @return the account
+   */
+  AccountData getAccountWithID(GetAccountRequestDTO getAccountRequestDTO);
 }

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/VaultAdminImpl.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/VaultAdminImpl.java
@@ -16,11 +16,13 @@ import com.amazonaws.util.StringUtils;
 import com.scality.osis.vaultadmin.impl.cache.Cache;
 import com.scality.osis.vaultadmin.impl.cache.CacheConstants;
 import com.scality.osis.vaultadmin.impl.cache.CacheFactory;
+import com.scality.vaultclient.dto.AccountData;
 import com.scality.vaultclient.dto.AssumeRoleResult;
 import com.scality.vaultclient.dto.CreateAccountRequestDTO;
 import com.scality.vaultclient.dto.CreateAccountResponseDTO;
 import com.scality.vaultclient.dto.GenerateAccountAccessKeyRequest;
 import com.scality.vaultclient.dto.GenerateAccountAccessKeyResponse;
+import com.scality.vaultclient.dto.GetAccountRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsResponseDTO;
 import com.scality.vaultclient.services.AccountServicesClient;
@@ -304,5 +306,17 @@ public class VaultAdminImpl implements VaultAdmin{
   @Override
   public GenerateAccountAccessKeyResponse getAccountAccessKey(GenerateAccountAccessKeyRequest generateAccountAccessKeyRequest) {
     return ExternalServiceFactory.executeVaultService(vaultAccountClient::generateAccountAccessKey, generateAccountAccessKeyRequest);
+  }
+
+  /**
+   * Get account with account id
+   * <p>This method will get the account from Vault using Account ID.
+   *
+   * @param getAccountRequestDTO the get account request dto
+   * @return the account
+   */
+  @Override
+  public AccountData getAccountWithID(GetAccountRequestDTO getAccountRequestDTO) {
+    return ExternalServiceFactory.executeVaultService(vaultAccountClient::getAccount, getAccountRequestDTO);
   }
 }

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/VaultServiceException.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/VaultServiceException.java
@@ -18,8 +18,19 @@ public class VaultServiceException extends ResponseStatusException {
 
   private static final long serialVersionUID = 8292089200348420677L;
 
+  private String errorCode = "";
+
+  public String getErrorCode() {
+    return errorCode;
+  }
+
   public VaultServiceException(HttpStatus status, String message) {
     super(status, message);
+  }
+
+  public VaultServiceException(HttpStatus status, String errorCode, String message) {
+    super(status, message);
+    this.errorCode = errorCode;
   }
 
   public VaultServiceException(HttpStatus status, String messageCode, Throwable cause) {

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/utils/ErrorUtils.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/utils/ErrorUtils.java
@@ -22,7 +22,7 @@ public final class ErrorUtils {
 
   public static VaultServiceException parseError(VaultClientException vaultClientException) {
       return new VaultServiceException(
-              HttpStatus.valueOf(vaultClientException.getStatusCode()), vaultClientException.getErrorCode());
+              HttpStatus.valueOf(vaultClientException.getStatusCode()), vaultClientException.getErrorCode(), vaultClientException.getErrorMessage());
   }
 
   public static boolean isSuccessful(int statusCode) {

--- a/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/VaultAdminImplTest.java
+++ b/vault-admin-client/src/test/java/com/scality/osis/vaultadmin/impl/VaultAdminImplTest.java
@@ -67,7 +67,7 @@ public class VaultAdminImplTest extends BaseTest {
             vaultAdminImpl.createAccount(createAccountRequestDTO);
         });
         assertEquals(409, exception.getStatus().value());
-        assertEquals("EntityAlreadyExists", exception.getReason());
+        assertEquals("EntityAlreadyExists", exception.getErrorCode());
 
         //reinit the default mocks
         initMocks();


### PR DESCRIPTION
This PR is about implementing an asynchronous `setupAssumeRole` subroutine, after `create-account`, that prepares an account to be used by `assumeRoleBackbeat` during user flows (IAM).
ref: https://github.com/scality/vmware-ose-scality/blob/c1cc56602b590be96bfda10223fd7da94132b909/Design.md#setupassumerole-subroutine

* `setupAssumeRole` subroutine LOGIC:
  1 Call `generateAccountAccessKey` with `durationSeconds` to generate temp creds
  2 Call IAM `createRole` for `OSIS` super admin role with `assumerole` policy
  3 Call IAM `createPolicy` to create admin policy with full IAM access
  4 Call IAM `attachRolePolicy` to attach `OSIS` role with admin policy
  5 Call `deleteAccessKey` to delete the access key for the account

* Async logic:
  * Enabled Spring Async functionality
  * Moved `setupAssumeRole()` to a new class so @async will function
  * Added environment variables in application.properties for async threadpool

* Role auto generation logic:
  * If the `AssumeRoleBackbeat` API returns a `NoSuchEntity` error with description, `Role does not exist`, then use vaultclient to invoke `get-account` with `accountID` to retrieve the `accountName` and then invoke the `setupAssumeRole` subroutine to regenerate the role.