### PR TITLE
feature:S3C-4407 Integrating Redis Sentinel using Lettuce Redis client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,7 @@ configure(allprojects) {
         compile "org.springframework.boot:spring-boot-starter-hateoas:$springBootVersion"
         compile "org.springframework.boot:spring-boot-starter-data-jpa:$springBootVersion"
         compile "org.springframework.boot:spring-boot-starter-security:$springBootVersion"
+        compile "org.springframework.boot:spring-boot-starter-data-redis:$springBootVersion"
         testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion") {
             exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
         }

--- a/osis-core/src/main/java/com/scality/osis/configuration/SpringRedisConfig.java
+++ b/osis-core/src/main/java/com/scality/osis/configuration/SpringRedisConfig.java
@@ -1,0 +1,60 @@
+/**
+ *Copyright 2021 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.configuration;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisSentinelConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+import java.util.HashSet;
+
+@Configuration
+public class SpringRedisConfig {
+    @Autowired
+    private RedisProperties redisProperties;
+
+    @Bean
+    protected LettuceConnectionFactory redisConnectionFactory() {
+        RedisSentinelConfiguration sentinelConfig
+                = new RedisSentinelConfiguration(
+                            redisProperties.getSentinel().getMaster(),
+                            new HashSet<>(redisProperties.getSentinel().getNodes()));
+
+        sentinelConfig.setSentinelPassword(RedisPassword.of(redisProperties.getPassword()));
+        sentinelConfig.setPassword(RedisPassword.of(redisProperties.getPassword()));
+
+        LettuceClientConfiguration lettuceClientConfig = redisProperties.isSsl() ?
+                                            LettuceClientConfiguration.builder().useSsl().build() :
+                                            LettuceClientConfiguration.defaultConfiguration();
+        return new LettuceConnectionFactory(sentinelConfig, lettuceClientConfig);
+    }
+
+    @Bean
+    public <T> RedisTemplate<String, T> redisTemplate() {
+        RedisTemplate<String, T> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setDefaultSerializer(RedisSerializer.json());
+        redisTemplate.setKeySerializer(RedisSerializer.string());
+        redisTemplate.setValueSerializer(RedisSerializer.string());
+        redisTemplate.setHashKeySerializer(RedisSerializer.string());
+        // Setting JSON to/from Redis byte[] Serialization/Deserialization
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.afterPropertiesSet();
+
+        return redisTemplate;
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/redis/service/IRedisRepository.java
+++ b/osis-core/src/main/java/com/scality/osis/redis/service/IRedisRepository.java
@@ -1,0 +1,16 @@
+/**
+ *Copyright 2021 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.redis.service;
+
+public interface IRedisRepository<T> {
+    void save(String key, T value);
+
+    T get(String key);
+
+    void delete(String key);
+
+    Boolean hasKey(String key);
+}

--- a/osis-core/src/main/java/com/scality/osis/redis/service/ScalityRedisRepository.java
+++ b/osis-core/src/main/java/com/scality/osis/redis/service/ScalityRedisRepository.java
@@ -1,0 +1,55 @@
+/**
+ *Copyright 2021 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.redis.service;
+
+import com.scality.osis.utils.ScalityModelConverter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.annotation.PostConstruct;
+
+import static com.scality.osis.utils.ScalityConstants.DEFAULT_REDIS_HASH_KEY;
+
+@Repository
+public class ScalityRedisRepository<T> implements IRedisRepository<T> {
+
+    @Autowired
+    RedisTemplate<String, T> redisTemplate;
+
+    @Value("${osis.scality.redis.credentials.hashKey}")
+    String osisRedisHashKey = DEFAULT_REDIS_HASH_KEY;
+
+    private HashOperations<String, String, T> hashOperations;
+
+    @PostConstruct
+    public void postInit() {
+        hashOperations = redisTemplate.opsForHash();
+    }
+
+    @Override
+    public void save(String key, T value) {
+        hashOperations.put(ScalityModelConverter.toRedisHashName(osisRedisHashKey), key, value);
+    }
+
+    @Override
+    public T get(String key) {
+        return hashOperations.get(ScalityModelConverter.toRedisHashName(osisRedisHashKey), key);
+    }
+
+    @Override
+    public void delete(String key) {
+        hashOperations.delete(ScalityModelConverter.toRedisHashName(osisRedisHashKey), key);
+    }
+
+    @Override
+    public Boolean hasKey(String key) {
+        return hashOperations.hasKey(ScalityModelConverter.toRedisHashName(osisRedisHashKey), key);
+    }
+
+}

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -88,4 +88,7 @@ public final class ScalityConstants {
                                                                                         "\"s3:*\"\n      ],\n      " +
                                                                                     "\"Resource\": \"*\"\n    }\n  " +
                                                                         "]\n}";
+
+    public static final String DEFAULT_REDIS_HASH_KEY = "s3credentials";
+    public static final String DEFAULT_REDIS_PREFIX = "osis:";
 }

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -293,6 +293,10 @@ public final class ScalityModelConverter {
         return DEFAULT_USER_POLICY_DESCRIPTION.replace(ACCOUNT_ID_REGEX, accountID);
     }
 
+    public static String toRedisHashName(String osisRedisHashKey) {
+        return DEFAULT_REDIS_PREFIX + osisRedisHashKey;
+    }
+
     /**
      * Generates tenant email string using tenant name.
      *  example email address: tenant.name@osis.scality.com

--- a/osis-core/src/test/java/com/scality/osis/ScalityAppEnvTest.java
+++ b/osis-core/src/test/java/com/scality/osis/ScalityAppEnvTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -394,5 +395,97 @@ public class ScalityAppEnvTest {
 
         // Verify the results
         assertEquals(result, "osis", "testGetAssumeRoleName failed");
+    }
+
+    @Test
+    public void testGetAccountAKDurationSeconds() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.vault.account.accessKey.durationSeconds")).thenReturn("120");
+
+        // Run the test
+        final long result = appEnvUnderTest.getAccountAKDurationSeconds();
+
+        // Verify the results
+        assertThat(result).isEqualTo(120L);
+    }
+
+    @Test
+    public void testGetAccountAKDurationSecondsEnvironmentReturnsNull() {
+        // Setup
+
+        // Run the test
+        final long result = appEnvUnderTest.getAccountAKDurationSeconds();
+
+        // Verify the results
+        assertThat(result).isEqualTo(120L);
+    }
+
+    @Test
+    public void testGetAsyncExecutorCorePoolSize() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.async.corePoolSize")).thenReturn("10");
+
+        // Run the test
+        final int result = appEnvUnderTest.getAsyncExecutorCorePoolSize();
+
+        // Verify the results
+        assertThat(result).isEqualTo(10);
+    }
+
+    @Test
+    public void testGetAsyncExecutorCorePoolSizeEnvironmentReturnsNull() {
+        // Setup
+
+        // Run the test
+        final int result = appEnvUnderTest.getAsyncExecutorCorePoolSize();
+
+        // Verify the results
+        assertThat(result).isEqualTo(10);
+    }
+
+    @Test
+    public void testGetAsyncExecutorMaxPoolSize() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.async.maxPoolSize")).thenReturn("10");
+
+        // Run the test
+        final int result = appEnvUnderTest.getAsyncExecutorMaxPoolSize();
+
+        // Verify the results
+        assertThat(result).isEqualTo(10);
+    }
+
+    @Test
+    public void testGetAsyncExecutorMaxPoolSizeEnvironmentReturnsNull() {
+        // Setup
+
+        // Run the test
+        final int result = appEnvUnderTest.getAsyncExecutorMaxPoolSize();
+
+        // Verify the results
+        assertThat(result).isEqualTo(10);
+    }
+
+    @Test
+    public void testGetAsyncExecutorQueueCapacity() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.async.queueCapacity")).thenReturn("500");
+
+        // Run the test
+        final int result = appEnvUnderTest.getAsyncExecutorQueueCapacity();
+
+        // Verify the results
+        assertThat(result).isEqualTo(500);
+    }
+
+    @Test
+    public void testGetAsyncExecutorQueueCapacityEnvironmentReturnsNull() {
+        // Setup
+
+        // Run the test
+        final int result = appEnvUnderTest.getAsyncExecutorQueueCapacity();
+
+        // Verify the results
+        assertThat(result).isEqualTo(500);
     }
 }

--- a/osis-core/src/test/java/com/scality/osis/redis/service/ScalityRedisRepositoryTest.java
+++ b/osis-core/src/test/java/com/scality/osis/redis/service/ScalityRedisRepositoryTest.java
@@ -1,0 +1,72 @@
+package com.scality.osis.redis.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class ScalityRedisRepositoryTest {
+
+    @Mock
+    private HashOperations<String, String, String> mockHashOperations;
+
+    @InjectMocks
+    private ScalityRedisRepository scalityRedisRepositoryUnderTest;
+
+    @BeforeEach
+    public void setUp() {
+        initMocks(this);
+        ReflectionTestUtils.setField(scalityRedisRepositoryUnderTest, "hashOperations", mockHashOperations);
+    }
+
+    @Test
+    public void testSave() {
+        // Setup
+
+        // Run the test
+        scalityRedisRepositoryUnderTest.save("key", "value");
+
+        // Verify the results
+        verify(mockHashOperations).put(any(), any(), any());
+    }
+
+    @Test
+    public void testGet() {
+        // Setup
+        when(mockHashOperations.get(any(), any())).thenReturn("value");
+
+        // Run the test
+        final String result = (String) scalityRedisRepositoryUnderTest.get("key");
+
+        // Verify the results
+        assertEquals("value", result);
+    }
+
+    @Test
+    public void testDelete() {
+        // Setup
+
+        // Run the test
+        scalityRedisRepositoryUnderTest.delete("key");
+
+        // Verify the results
+        verify(mockHashOperations).delete(any(), any());
+    }
+
+    @Test
+    public void testHasKey() {
+        // Setup
+
+        // Run the test
+        scalityRedisRepositoryUnderTest.hasKey("key");
+
+        // Verify the results
+        verify(mockHashOperations).hasKey(any(), any());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -68,3 +68,13 @@ logging.level.com.scality=INFO
 osis.scality.async.maxPoolSize=10
 osis.scality.async.corePoolSize=10
 osis.scality.async.queueCapacity=500
+
+# Redis config
+spring.cache.type=redis
+spring.redis.ssl=false
+spring.redis.timeout=60000
+spring.redis.password=
+spring.redis.sentinel.master=themaster
+spring.redis.sentinel.nodes=localhost:26379, localhost:26380, localhost:26381
+spring.redis.lettuce.shutdown-timeout=200ms
+osis.scality.redis.credentials.hashKey=s3credentials


### PR DESCRIPTION
1. Added Lettuce Redis client config to integrate Redis
2. Connecting to Redis Sentinel nodes using SSL or Default
3. Created Redis Repository class for CRUD operations on Redis Hash using serialization of an object
4. Added test cases for Redis Repo

Design PR:
#45
Design doc: https://github.com/scality/vmware-ose-scality/blob/documentation/S3C-4390-ose-design-secret-key/Design.md