### PR TITLE
improvement:S3C-4510 Support S3 objects sync

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -32,6 +32,10 @@ public final class ScalityConstants {
 
     public static final String REPO_KEY_SEPARATOR = "__";
 
+    public static final String USER_PATH_SEPARATOR = "/";
+
+    public static final String UUID_REGEX = "^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$";
+
     public static final String ICON_PATH = "/scalitylogo.png";
 
     public static final String IAM_PREFIX = "/";

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityUtils.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityUtils.java
@@ -7,19 +7,30 @@
 package com.scality.osis.utils;
 
 import java.net.URI;
+import java.util.regex.Pattern;
 
 import static com.scality.osis.utils.ScalityConstants.ICON_PATH;
+import static com.scality.osis.utils.ScalityConstants.UUID_REGEX;
 
 /**
  * Helper class with static common utils methods.
  */
 public final class ScalityUtils {
+    private final static Pattern UUID_REGEX_PATTERN =
+            Pattern.compile(UUID_REGEX);
 
     private ScalityUtils() {
     }
 
     public static URI getLogoUri(String domain) {
         return URI.create(domain + ICON_PATH);
+    }
+
+    public static boolean isValidUUID(String str) {
+        if (str == null) {
+            return false;
+        }
+        return UUID_REGEX_PATTERN.matcher(str).matches();
     }
 
 }

--- a/osis-core/src/test/java/com/scality/osis/service/impl/BaseOsisServiceTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/BaseOsisServiceTest.java
@@ -287,7 +287,7 @@ public class BaseOsisServiceTest {
     }
 
     protected void initGetAccountMocks() {
-        when(vaultAdminMock.getAccountWithID(any(GetAccountRequestDTO.class)))
+        when(vaultAdminMock.getAccount(any(GetAccountRequestDTO.class)))
                 .thenAnswer((Answer<AccountData>) invocation -> {
 
                     final GetAccountRequestDTO request = invocation.getArgument(0);
@@ -297,7 +297,7 @@ public class BaseOsisServiceTest {
                     final String emailAddress = request.getEmailAddress() ==null ? SAMPLE_SCALITY_ACCOUNT_EMAIL : request.getEmailAddress();
                     final String canonicalId = request.getCanonicalId() ==null ? SAMPLE_ID : request.getCanonicalId();
                     final Map<String, String> customAttributestes  = new HashMap<>() ;
-                    customAttributestes.put(CD_TENANT_ID_PREFIX + UUID.randomUUID(), "");
+                    customAttributestes.put(CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID, "");
 
                     final AccountData data = new AccountData();
                     data.setEmailAddress(emailAddress);

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
@@ -136,7 +136,7 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         // Setup
         final long offset = 0L;
         final long limit = 1000L;
-        final String filter = CD_TENANT_ID_PREFIX + TEST_STR;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID;
 
         // Run the test
         // Call Scality Osis service to query tenants
@@ -147,7 +147,26 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         assertEquals(offset, response.getPageInfo().getOffset());
         assertEquals(limit, response.getPageInfo().getLimit());
         assertEquals(1, response.getItems().size());
-        assertEquals(TEST_STR, response.getItems().get(0).getCdTenantIds().get(0));
+        assertEquals(SAMPLE_CD_TENANT_ID, response.getItems().get(0).getCdTenantIds().get(0));
+    }
+
+    @Test
+    public void testQueryTenantsWithNonUUID() {
+        // Setup
+        final long offset = 0L;
+        final long limit = 1000L;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_TENANT_ID;
+
+        // Run the test
+        // Call Scality Osis service to query tenants
+        final PageOfTenants response = scalityOsisServiceUnderTest.queryTenants(offset, limit, filter);
+
+        // Verify the results
+        assertEquals(1, response.getPageInfo().getTotal());
+        assertEquals(offset, response.getPageInfo().getOffset());
+        assertEquals(limit, response.getPageInfo().getLimit());
+        assertEquals(1, response.getItems().size());
+        assertEquals(SAMPLE_CD_TENANT_ID, response.getItems().get(0).getCdTenantIds().get(0));
     }
 
     @Test
@@ -155,7 +174,7 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         // Setup
         final long offset = 2000L;
         final long limit = 1000L;
-        final String filter = CD_TENANT_ID_PREFIX + TEST_STR;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID;
         // Run the test
         // Call Scality Osis service to list tenants
         final PageOfTenants response = scalityOsisServiceUnderTest.queryTenants(offset, limit, filter);
@@ -166,7 +185,7 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         assertEquals(offset, response.getPageInfo().getOffset());
         assertEquals(limit, response.getPageInfo().getLimit());
         assertEquals(1, response.getItems().size());
-        assertEquals(TEST_STR, response.getItems().get(0).getCdTenantIds().get(0));
+        assertEquals(SAMPLE_CD_TENANT_ID, response.getItems().get(0).getCdTenantIds().get(0));
     }
 
     @Test
@@ -193,7 +212,7 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         // Setup
         final long offset = 3000L;
         final long limit = 1000L;
-        final String filter = CD_TENANT_ID_PREFIX + TEST_STR;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID;
 
         when(vaultAdminMock.listAccounts(anyLong(),any(ListAccountsRequestDTO.class)))
                 .thenAnswer((Answer<ListAccountsResponseDTO>) invocation -> {

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
@@ -128,6 +128,26 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
     }
 
     @Test
+    public void testQueryUsersWithNonUUID() {
+        // Setup
+        final long offset = 0L;
+        final long limit = 1000L;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_TENANT_ID + QUERY_USER_FILTER_SEPARATOR + DISPLAY_NAME_PREFIX + TEST_NAME;
+        // cd_tenant_id==e7ecb16e-f6b7-4d34-ad4e-5da5d5c8317;display_name%3D%3D==name
+
+        // Run the test
+        final PageOfUsers response = scalityOsisServiceUnderTest.queryUsers(offset, limit, filter);
+
+        // Verify the results
+        assertEquals(1, response.getPageInfo().getTotal());
+        assertEquals(offset, response.getPageInfo().getOffset());
+        assertEquals(limit, response.getPageInfo().getLimit());
+        assertEquals(1, response.getItems().size());
+        assertEquals(TEST_NAME, response.getItems().get(0).getUsername());
+        assertTrue(response.getItems().get(0).getTenantId().contains(SAMPLE_TENANT_ID));
+    }
+
+    @Test
     public void testQueryUsersInvalidCdTenantID() {
         // Setup
         final long offset = 0L;

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
@@ -222,7 +222,7 @@ public class ScalityModelConverterTest {
     @Test
     public void  testToCreateUserRequest() {
         final OsisUser osisUser = new OsisUser();
-        osisUser.setCanonicalUserId(TEST_USER_ID);
+        osisUser.setCanonicalUserId(TEST_CANONICAL_ID);
         osisUser.setTenantId(TEST_TENANT_ID);
         osisUser.setActive(true);
         osisUser.setUsername(TEST_NAME);
@@ -238,6 +238,7 @@ public class ScalityModelConverterTest {
         assertTrue(createUserRequest.getPath().contains(OsisUser.RoleEnum.TENANT_USER.getValue()));
         assertTrue(createUserRequest.getPath().contains(SAMPLE_SCALITY_USER_EMAIL));
         assertTrue(createUserRequest.getPath().contains(TEST_TENANT_ID));
+        assertTrue(createUserRequest.getPath().contains(TEST_CANONICAL_ID));
     }
 
     @Test
@@ -357,7 +358,8 @@ public class ScalityModelConverterTest {
         final String path = "/"+ TEST_NAME +"/"
                 + OsisUser.RoleEnum.TENANT_USER.getValue() +"/"
                 + SAMPLE_SCALITY_USER_EMAIL  + "/"
-                + TEST_TENANT_ID  + "/";
+                + TEST_TENANT_ID  + "/"
+                + TEST_CANONICAL_ID  + "/";
 
         final User user = new User(path, TEST_USER_ID, TEST_USER_ID, "arn", new GregorianCalendar(2019, Calendar.JANUARY, 1).getTime());
 
@@ -378,7 +380,7 @@ public class ScalityModelConverterTest {
         assertEquals(SAMPLE_SCALITY_USER_EMAIL, osisUser.getEmail());
         assertEquals(TEST_TENANT_ID, osisUser.getCdTenantId());
         assertEquals(OsisUser.RoleEnum.TENANT_USER, osisUser.getRole());
-        assertEquals(TEST_USER_ID, osisUser.getCanonicalUserId());
+        assertEquals(TEST_CANONICAL_ID, osisUser.getCanonicalUserId());
         assertTrue(osisUser.getActive());
     }
 
@@ -404,6 +406,18 @@ public class ScalityModelConverterTest {
 
         // Verify the results
         assertEquals(TEST_NAME, osisUserName);
+    }
+
+    @Test
+    public void testExtractCdTenantId() {
+        // Setup
+        final String filter = "cd_tenant_id==" + SAMPLE_CD_TENANT_ID ;
+
+        // Run the test
+        final String cdTenantId = ScalityModelConverter.extractCdTenantId(filter);
+
+        // Verify the results
+        assertEquals(SAMPLE_CD_TENANT_ID, cdTenantId);
     }
 
     @Test

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
@@ -13,7 +13,7 @@ public final class ScalityTestUtils {
 
     public static final String SAMPLE_TENANT_ID = "123123123123";
     public static final String SAMPLE_ID = "bfc0d4a51e06481cbc917e9d96e52d81";
-    public static final String SAMPLE_CD_TENANT_ID = "e7ecb16e-f6b7-4d34-ad4e-5da5d5c8317";
+    public static final String SAMPLE_CD_TENANT_ID = "5db7b952-66b9-4164-bfe2-7bab25ac9011";
     public static final String SAMPLE_TENANT_NAME = "tenant name";
     public static final List<String> SAMPLE_CD_TENANT_IDS = new ArrayList<>(
             Arrays.asList(
@@ -47,6 +47,7 @@ public final class ScalityTestUtils {
     public static final String NULL_ERR ="Expected Value. Found Null";
     public static final String INVALID_URL_URL ="Invalid URL";
     public static final String TEST_USER_ID ="userId";
+    public static final String TEST_CANONICAL_ID ="canonicalID";
     public static final String TEST_NAME ="name";
     public static final String TEST_POLICY_ARN ="policy-arn";
     public static final String TEST_ACCESS_KEY = "access_key";

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityUtilsTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityUtilsTest.java
@@ -1,0 +1,20 @@
+package com.scality.osis.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ScalityUtilsTest {
+
+    @Test
+    public void testIsValidUUID() {
+        assertThat(ScalityUtils.isValidUUID(UUID.randomUUID().toString())).isTrue();
+    }
+
+    @Test
+    public void testIsInValidUUID() {
+        assertThat(ScalityUtils.isValidUUID("str")).isFalse();
+    }
+}

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/VaultAdmin.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/VaultAdmin.java
@@ -103,7 +103,7 @@ public interface VaultAdmin {
    * @param getAccountRequestDTO the get account request dto
    * @return the account
    */
-  AccountData getAccountWithID(GetAccountRequestDTO getAccountRequestDTO);
+  AccountData getAccount(GetAccountRequestDTO getAccountRequestDTO);
 
   /**
    * Searches all accounts and returns Vault accountID w.r.t cdTenantId filter key.

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/VaultAdminImpl.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/impl/VaultAdminImpl.java
@@ -354,7 +354,7 @@ public class VaultAdminImpl implements VaultAdmin{
    * @return the account
    */
   @Override
-  public AccountData getAccountWithID(GetAccountRequestDTO getAccountRequestDTO) {
+  public AccountData getAccount(GetAccountRequestDTO getAccountRequestDTO) {
     return ExternalServiceFactory.executeVaultService(vaultAccountClient::getAccount, getAccountRequestDTO);
   }
 }


### PR DESCRIPTION
Description:
Support S3 objects synchronization with changes from other sources (S3 browser, CLI).

Logic:
1. `CreateUser` stores `canonicalID` in user path
2. `listUsers`,`queryUsers`,`getUser` returns canonicalID from user path
3. `queryTenant`: if cdTenantID is not UUID  call getAccount
4. `queryUser`: if cdTenantID is not an UUID skip getAccountID