### PR TITLE
feature:OSIS-1 get-user using canonicalID

### DIFF
--- a/Design.md
+++ b/Design.md
@@ -213,7 +213,10 @@ This API will return the user.
 
 ### Get User with Canonical ID
 This API will return the user.
-1. The `get-user` API will be called using assumed role credentials with canonical_id as username
+1. The `get-account` API will be called using vaultclient with the provided `canonical-id` and account details will be used to fill tenant details of the response.
+1. The `list-users` API will be called with `offset` as 0 and `limit` as 1000 and the last user values in the response will be used to fill the user details of the response.
+    * _`canonical-id` in Scality is defined with respect to an account and any specific user cannot be retrieved using only the `canonicalID`_
+    * `get-user-with-canonical-id` API will be called by OSE only when user APIs does not return the `canonical-id` for any user.  
 
 ### Head User
 This API will return if user exists or not.

--- a/docs/api-compatibility-matrix.md
+++ b/docs/api-compatibility-matrix.md
@@ -35,7 +35,7 @@ Legend
 | headUser | . | . | . |
 | updateUserStatus * | . | . | . |
 | deleteUser * | . | . | . |
-| getUserWithCanonicalID * | . | . | . |
+| getUserWithCanonicalID * | . | . | x |
 | queryCredentials * | . | . | . |
 | listCredentials * | . | x | x |
 | createCredential * | . | x | x |

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -104,6 +104,9 @@ public final class ScalityConstants {
     public static final String MASKED_SENSITIVE_DATA_STR = "***Sensitive Data Redacted***";
     public static final String SECRET_KEY_REGEX = "(secretKey\\\":\\\")([^\\\"]+)";
 
+    public static final long DEFAULT_MIN_OFFSET = 0l;
+    public static final long DEFAULT_MAX_LIMIT = 1000l;
+
     // Cipher Constants
     public static final String NAME_AES_256_GCM_CIPHER = "AES256GCM";
     public final static int DEFAULT_AES_GCM_NONCE_LENGTH = 12;

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -231,6 +231,18 @@ public final class ScalityModelConverter {
                 .build();
     }
 
+    /**
+     * Creates GetAccountRequestDTO using canonicalID
+     * @param canonicalID the canonicalID
+     *
+     * @return the GetAccountRequestDTO
+     */
+    public static GetAccountRequestDTO toGetAccountRequestWithCanonicalID(String canonicalID) {
+        return GetAccountRequestDTO.builder()
+                .canonicalId(canonicalID)
+                .build();
+    }
+
     public static String toAdminPolicyArn(String accountID) {
         return ACCOUNT_ADMIN_POLICY_ARN_REGEX
                 .replace(ACCOUNT_ID_REGEX, accountID);
@@ -401,6 +413,33 @@ public final class ScalityModelConverter {
                 .displayName(nameFromUserPath(user.getPath()))
                 .role(roleFromUserPath(user.getPath()))
                 .email(emailFromUserPath(user.getPath()));
+    }
+
+    /**
+     * Converts IAM User object to OSIS User object for get user with canonical id
+     *
+     * @return the osis User
+     */
+    public static OsisUser toCanonicalOsisUser(AccountData account, List<OsisUser> users) {
+        final OsisUser osisUser = new OsisUser();
+
+        osisUser.setTenantId(account.getId());
+        if(!account.getCustomAttributes().isEmpty()) {
+            osisUser.setCdTenantId(ScalityModelConverter.toOsisCDTenantIds(account.getCustomAttributes()).get(0));
+        }
+        osisUser.setCanonicalUserId(account.getCanonicalId());
+
+        if(!users.isEmpty()) {
+            OsisUser user = users.get(users.size() - 1);
+            osisUser.setUsername(user.getUsername());
+            osisUser.setUserId(user.getUserId());
+            osisUser.setCdUserId(user.getCdUserId());
+            osisUser.setEmail(user.getEmail());
+        }
+        osisUser.setRole(OsisUser.RoleEnum.TENANT_ADMIN);
+        osisUser.setActive(Boolean.TRUE);
+
+        return osisUser;
     }
 
     /**
@@ -613,4 +652,5 @@ public final class ScalityModelConverter {
     public static String maskSecretKey(String logStatement) {
         return logStatement.replaceAll(SECRET_KEY_REGEX, "$1" + MASKED_SENSITIVE_DATA_STR);
     }
+
 }

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
@@ -284,13 +284,36 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
     }
 
     @Test
-    public void testGetUser1() {
+    public void testGetUserWithCanonicalID() {
         // Setup
 
         // Run the test
-        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getUser("canonicalUserId"), NOT_IMPLEMENTED_EXCEPTION_ERR);
+        final OsisUser osisUser = scalityOsisServiceUnderTest.getUser(TEST_CANONICAL_ID);
 
         // Verify the results
+        assertEquals(SAMPLE_TENANT_ID, osisUser.getTenantId());
+        assertEquals(SAMPLE_CD_TENANT_ID, osisUser.getCdTenantId());
+        assertEquals(TEST_CANONICAL_ID, osisUser.getCanonicalUserId());
+        assertNotNull(osisUser.getUserId());
+        assertNotNull(osisUser.getCdUserId());
+        assertNotNull(osisUser.getUsername());
+        assertNotNull(osisUser.getRole());
+        assertTrue(osisUser.getActive());
+
+        // Verify the results
+    }
+
+    @Test
+    public void testGetUserWithCanonicalIDErr() {
+        // Setup
+        when(vaultAdminMock.getAccount(any()))
+                .thenAnswer((Answer<AccountData>) invocation -> {
+                    throw new VaultServiceException(HttpStatus.NOT_FOUND, "The Entity doesn't exist");
+                });
+
+        // Run the test
+        // Verify the results
+        assertThrows(VaultServiceException.class, () -> scalityOsisServiceUnderTest.getUser(TEST_CANONICAL_ID));
     }
 
     @Test


### PR DESCRIPTION
Logic:
1. The `get-account` API will be called using vaultclient with the provided `canonical-id` and account details will be used to fill tenant details of the response.
1. The `list-users` API will be called with `offset` as 0 and `limit` as 1000 and the last user values in the response will be used to fill the user details of the response.
    * _`canonical-id` in Scality is defined with respect to an account and any specific user cannot be retrieved using only the `canonicalID`_
    * `get-user-with-canonical-id` API will be called by OSE only when user APIs does not return the `canonical-id` for any user.