### PR TITLE
bugfix:S3C-4487 Non osis user returned in `listUsers`

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -42,6 +42,8 @@ public final class ScalityConstants {
 
     public static final String NOT_AVAILABLE = "Not Available";
 
+    public static final String NON_OSIS_USR = "NON OSIS USER";
+
     public static final String DEFAULT_ACCOUNT_AK_DURATION_SECONDS = "120";
 
     public static final String DEFAULT_ADMIN_POLICY_DESCRIPTION = "This is a admin role policy created for OSIS to IAM actions using AssumeRole for the $ACCOUNTID account";

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -465,7 +465,7 @@ public final class ScalityModelConverter {
     }
 
     private static String nameFromUserPath(String path) {
-        return path.split("/")[1];
+        return path.split("/").length > 1 ? path.split("/")[1] : NON_OSIS_USR;
     }
 
     private static OsisUser.RoleEnum roleFromUserPath(String path) {


### PR DESCRIPTION
Description:
As user which is not created by OSIS will not have `name` in the `path`, defaulting the value to a `Non OSIS User` string.