### PR TITLE
feature:OSIS-5 Get S3 Credentials

### DIFF
--- a/Design.md
+++ b/Design.md
@@ -275,8 +275,12 @@ This API deletes the S3 credential of the user.
 1. `delete-access-key` api will be called using assumed role credentials.
 
 ### Get S3 Credential
-This API return S3 credential of the user.
-1. `get-access-key` api will be called using assumed role credentials.
+This API return S3 credential of the user with the provided access key.
+1. `list-access-keys` api will be called using assumed role credentials.
+2. Extract the provided `access-key` details from the response
+3. Retrieve the secret key, formatted as `<Username>__<AccessKeyID>`, from Redis Sentinel.
+4. Decrypt the secret key (For more, see [SecretKey-Encryption-Strategy](#SecretKey-Encryption-Strategy)) and add it to the response.
+5. If the key is not present in the Redis Sentinel return the response with `secretKey` value as `Not Available`.
 
 ## Miscellaneous APIs:
 

--- a/docs/api-compatibility-matrix.md
+++ b/docs/api-compatibility-matrix.md
@@ -39,7 +39,7 @@ Legend
 | queryCredentials * | . | . | . |
 | listCredentials * | . | x | x |
 | createCredential * | . | x | x |
-| getCredential * | . | . | . |
+| getCredential * | . | . | x |
 | updateCredentialStatus | . | . | . |
 | deleteCredential | . | . | . |
 | getUsage | o | o | o |

--- a/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
+++ b/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
@@ -1,15 +1,16 @@
 /**
- * Copyright 2020 VMware, Inc.
- * SPDX-License-Identifier: Apache License 2.0
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2021 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
  */
 
-package com.vmware.osis.resource;
+package com.scality.osis.resource;
 
+import com.scality.osis.service.ScalityOsisService;
 import com.vmware.osis.annotation.NotImplement;
 import com.vmware.osis.model.*;
 import com.vmware.osis.model.exception.*;
 import com.vmware.osis.validation.Update;
-import com.vmware.osis.service.OsisService;
 import io.swagger.annotations.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,12 +27,12 @@ import java.util.Optional;
 
 @Api(tags = "OSIS")
 @RestController
-public class OsisController {
-    private static final Logger logger = LoggerFactory.getLogger(OsisController.class);
+public class ScalityOsisController {
+    private static final Logger logger = LoggerFactory.getLogger(com.scality.osis.resource.ScalityOsisController.class);
 
 
     @Autowired
-    private OsisService osisService;
+    private ScalityOsisService osisService;
 
     /**
      * POST /api/v1/tenants/{tenantId}/users/{userId}/s3credentials : Create S3 credential for the platform user

--- a/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
+++ b/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
@@ -297,7 +297,7 @@ public class ScalityOsisController {
             @Valid @RequestParam(value = "user_id", required = false) Optional<String> userId,
             @ApiParam(value = "The access key of the S3 credential to get", required = true)
             @PathVariable("accessKey") String accessKey) {
-        return osisService.getS3Credential(accessKey);
+        return osisService.getS3Credential(tenantId.orElse(""), userId.orElse(""), accessKey);
     }
 
 

--- a/osis-core/src/main/java/com/scality/osis/configuration/DocumentationConfig.java
+++ b/osis-core/src/main/java/com/scality/osis/configuration/DocumentationConfig.java
@@ -31,7 +31,7 @@ public class DocumentationConfig {
     private static final String DOC_TITLE = "Object Storage Interoperability Services API for Scality platform";
     private static final String DOC_DESCRIPTION = "This is VMware Cloud Director Object Storage Interoperability Services API for Scality platform.";
     private static final String DOC_VERSION = "1.0.0";
-    private static final String PROJECT_BASE = "com.vmware.osis";
+    private static final String PROJECT_BASE = "com.scality.osis";
 
     ApiInfo apiInfo() {
         return new ApiInfoBuilder()

--- a/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
+++ b/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
@@ -6,8 +6,10 @@
 
 package com.scality.osis.service;
 
+import com.vmware.osis.model.OsisS3Credential;
 import com.vmware.osis.service.OsisService;
 
 public interface ScalityOsisService extends OsisService {
+    OsisS3Credential getS3Credential(String tenantId, String userId, String accessKey);
 }
 

--- a/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
+++ b/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2020 VMware, Inc.
+ * Copyright 2021 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.service;
+
+import com.vmware.osis.service.OsisService;
+
+public interface ScalityOsisService extends OsisService {
+}
+

--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -13,6 +13,7 @@ import com.amazonaws.services.securitytoken.model.Credentials;
 import com.amazonaws.util.StringUtils;
 import com.scality.osis.ScalityAppEnv;
 import com.scality.osis.redis.service.IRedisRepository;
+import com.scality.osis.service.ScalityOsisService;
 import com.scality.osis.utils.CipherFactory;
 import com.scality.osis.utils.ScalityConstants;
 import com.scality.osis.utils.ScalityUtils;
@@ -30,7 +31,6 @@ import com.scality.vaultclient.dto.ListAccountsResponseDTO;
 import com.vmware.osis.model.*;
 import com.vmware.osis.model.exception.NotImplementedException;
 import com.vmware.osis.resource.OsisCapsManager;
-import com.vmware.osis.service.OsisService;
 import com.scality.osis.security.crypto.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,8 +62,8 @@ import static com.scality.osis.utils.ScalityConstants.ROLE_DOES_NOT_EXIST_ERR;
  */
 @Service
 @Primary
-public class ScalityOsisService implements OsisService {
-    private static final Logger logger = LoggerFactory.getLogger(ScalityOsisService.class);
+public class ScalityOsisServiceImpl implements ScalityOsisService {
+    private static final Logger logger = LoggerFactory.getLogger(ScalityOsisServiceImpl.class);
     private static final String S3_CAPABILITIES_JSON = "s3capabilities.json";
 
     @Autowired
@@ -89,7 +89,7 @@ public class ScalityOsisService implements OsisService {
     /**
      * Instantiates a new Scality osis service.
      */
-    public ScalityOsisService(){}
+    public ScalityOsisServiceImpl(){}
 
     /**
      * Instantiates a new Scality osis service.
@@ -98,7 +98,7 @@ public class ScalityOsisService implements OsisService {
      * @param vaultAdmin      the vault admin
      * @param osisCapsManager the osis caps manager
      */
-    public ScalityOsisService(ScalityAppEnv appEnv, VaultAdmin vaultAdmin, OsisCapsManager osisCapsManager){
+    public ScalityOsisServiceImpl(ScalityAppEnv appEnv, VaultAdmin vaultAdmin, OsisCapsManager osisCapsManager){
         this.appEnv = appEnv;
         this.vaultAdmin = vaultAdmin;
         this.osisCapsManager = osisCapsManager;

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -101,7 +101,6 @@ public final class ScalityModelConverter {
 
     /**
      * Creates Vault List Access Keys request
-     * @param limit the max number of items
      *
      * @param username the IAM User's username
      * @param limit the max number of the access keys in the response
@@ -562,7 +561,23 @@ public final class ScalityModelConverter {
                 .tenantId(tenantId)
                 .cdTenantId(cdTenantId)
                 .username(username)
-                .creationDate(Instant.now());
+                .creationDate(Instant.now())
+                .immutable(Boolean.TRUE);
+    }
+
+    public static OsisS3Credential toOsisS3Credentials(String tenantId, AccessKeyMetadata accessKeyMetadata, String secretKey) {
+        OsisS3Credential s3Credential = new OsisS3Credential()
+                .accessKey(accessKeyMetadata.getAccessKeyId())
+                .active(accessKeyMetadata.getStatus()
+                        .equalsIgnoreCase(StatusType.Active.toString()))
+                .userId(accessKeyMetadata.getUserName())
+                .cdUserId(accessKeyMetadata.getUserName())
+                .tenantId(tenantId)
+                .creationDate(accessKeyMetadata.getCreateDate().toInstant())
+                .immutable(Boolean.TRUE)
+                .secretKey(StringUtils.isEmpty(secretKey) ? ScalityConstants.NOT_AVAILABLE : secretKey);
+
+        return s3Credential;
     }
 
     /**
@@ -613,7 +628,8 @@ public final class ScalityModelConverter {
                         .userId(accessKeyMetadata.getUserName())
                         .cdUserId(accessKeyMetadata.getUserName())
                         .tenantId(tenantId)
-                        .creationDate(accessKeyMetadata.getCreateDate().toInstant());
+                        .creationDate(accessKeyMetadata.getCreateDate().toInstant())
+                        .immutable(Boolean.TRUE);
             if(null != secretKeyMap.get(accessKeyMetadata.getAccessKeyId())) {
                 // If secret key is available, add credential object to the list
                 s3Credential.setSecretKey(secretKeyMap.get(accessKeyMetadata.getAccessKeyId()));

--- a/osis-core/src/test/java/com/scality/osis/service/impl/BaseOsisServiceTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/BaseOsisServiceTest.java
@@ -35,7 +35,7 @@ public class BaseOsisServiceTest {
     @Mock
     protected static VaultAdminImpl vaultAdminMock;
 
-    protected static ScalityOsisService scalityOsisServiceUnderTest;
+    protected static ScalityOsisServiceImpl scalityOsisServiceUnderTest;
 
     protected static AsyncScalityOsisService asyncScalityOsisServiceUnderTest;
 
@@ -61,7 +61,7 @@ public class BaseOsisServiceTest {
     protected void init() {
         MockitoAnnotations.initMocks( this );
         initMocks();
-        scalityOsisServiceUnderTest = new ScalityOsisService(appEnvMock, vaultAdminMock, osisCapsManagerMock);
+        scalityOsisServiceUnderTest = new ScalityOsisServiceImpl(appEnvMock, vaultAdminMock, osisCapsManagerMock);
 
         asyncScalityOsisServiceUnderTest = new AsyncScalityOsisService();
         ReflectionTestUtils.setField(asyncScalityOsisServiceUnderTest, "vaultAdmin", vaultAdminMock);

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
@@ -284,6 +284,95 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
     }
 
     @Test
+    public void testGetS3Credential2() {
+        // Setup
+
+        // Run the test
+        final OsisS3Credential result = scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID, TEST_ACCESS_KEY);
+
+        // Verify the results
+        assertEquals(TEST_USER_ID, result.getCdUserId());
+        assertEquals(TEST_USER_ID, result.getUserId());
+        assertEquals(SAMPLE_TENANT_ID, result.getTenantId());
+        assertEquals(TEST_ACCESS_KEY, result.getAccessKey());
+        assertEquals(TEST_SECRET_KEY, result.getSecretKey());
+        assertTrue(result.getActive());
+        assertNotNull(result.getCreationDate());
+    }
+
+    @Test
+    public void testGetS3Credential2NoAdminPolicy() throws Exception {
+        // Setup
+        when(iamMock.listAccessKeys(any(ListAccessKeysRequest.class)))
+                .thenAnswer((Answer<ListAccessKeysResult>) invocation -> {
+                    final AmazonIdentityManagementException iamException = new AmazonIdentityManagementException("Forbidden");
+                    iamException.setStatusCode(HttpStatus.FORBIDDEN.value());
+                    throw iamException;
+                })
+                .thenAnswer((Answer<ListAccessKeysResult>) this::listAccessKeysMockResponse);
+
+        // Run the test
+        final OsisS3Credential result = scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID, TEST_ACCESS_KEY);
+
+        // Verify the results
+        assertEquals(TEST_USER_ID, result.getCdUserId());
+        assertEquals(TEST_USER_ID, result.getUserId());
+        assertEquals(SAMPLE_TENANT_ID, result.getTenantId());
+        assertEquals(TEST_ACCESS_KEY, result.getAccessKey());
+        assertEquals(TEST_SECRET_KEY, result.getSecretKey());
+        assertTrue(result.getActive());
+        assertNotNull(result.getCreationDate());
+    }
+
+    @Test
+    public void testGetS3Credential2WithNoKeyOnRedis() {
+        // Setup
+        when(redisRepositoryMock.hasKey(any())).thenReturn(Boolean.FALSE);
+
+        // Run the test
+        final OsisS3Credential result = scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID, TEST_ACCESS_KEY);
+
+        // Verify the results
+        assertEquals(TEST_USER_ID, result.getCdUserId());
+        assertEquals(TEST_USER_ID, result.getUserId());
+        assertEquals(SAMPLE_TENANT_ID, result.getTenantId());
+        assertEquals(TEST_ACCESS_KEY, result.getAccessKey());
+        assertEquals(NOT_AVAILABLE, result.getSecretKey());
+        assertTrue(result.getActive());
+        assertNotNull(result.getCreationDate());
+    }
+
+    @Test
+    public void testGetS3Credential2NotFound() {
+        // Setup
+
+        // Run the test
+        assertThrows(VaultServiceException.class, () ->  scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID, TEST_ACCESS_KEY_2));
+
+        // Verify the results
+    }
+
+    @Test
+    public void testGetS3Credential2EmptyUserID() {
+        // Setup
+
+        // Run the test
+        assertThrows(VaultServiceException.class, () ->  scalityOsisServiceUnderTest.getS3Credential("", TEST_USER_ID, TEST_ACCESS_KEY_2));
+
+        // Verify the results
+    }
+
+    @Test
+    public void testGetS3Credential2EmptyTenantID() {
+        // Setup
+
+        // Run the test
+        assertThrows(VaultServiceException.class, () ->  scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, "", TEST_ACCESS_KEY_2));
+
+        // Verify the results
+    }
+
+    @Test
     public void testGetUserWithCanonicalID() {
         // Setup
 

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import static com.scality.osis.utils.ScalityConstants.CD_TENANT_ID_PREFIX;
 import static com.scality.osis.utils.ScalityConstants.DEFAULT_USER_POLICY_DOCUMENT;
 import static com.scality.osis.utils.ScalityConstants.MASKED_SENSITIVE_DATA_STR;
+import static com.scality.osis.utils.ScalityConstants.NOT_AVAILABLE;
 import static com.scality.osis.utils.ScalityTestUtils.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -357,6 +358,50 @@ public class ScalityModelConverterTest {
     }
 
     @Test
+    public void testToOsisS3Credentials2() {
+        // Setup
+        final AccessKeyMetadata accesskeyMetaData = new AccessKeyMetadata()
+                .withAccessKeyId(TEST_ACCESS_KEY)
+                .withCreateDate(new Date())
+                .withStatus(StatusType.Active)
+                .withUserName(TEST_USER_ID);
+
+        // Run the test
+        final OsisS3Credential result = ScalityModelConverter.toOsisS3Credentials(TEST_TENANT_ID, accesskeyMetaData, TEST_SECRET_KEY);
+
+        // Verify the results
+        assertEquals(TEST_USER_ID, result.getCdUserId());
+        assertEquals(TEST_USER_ID, result.getUserId());
+        assertEquals(TEST_TENANT_ID, result.getTenantId());
+        assertEquals(TEST_ACCESS_KEY, result.getAccessKey());
+        assertEquals(TEST_SECRET_KEY, result.getSecretKey());
+        assertTrue(result.getActive());
+        assertNotNull(result.getCreationDate());
+    }
+
+    @Test
+    public void testToOsisS3Credentials2EmptySecretKey() {
+        // Setup
+        final AccessKeyMetadata accesskeyMetaData = new AccessKeyMetadata()
+                .withAccessKeyId(TEST_ACCESS_KEY)
+                .withCreateDate(new Date())
+                .withStatus(StatusType.Active)
+                .withUserName(TEST_USER_ID);
+
+        // Run the test
+        final OsisS3Credential result = ScalityModelConverter.toOsisS3Credentials(TEST_TENANT_ID, accesskeyMetaData, null);
+
+        // Verify the results
+        assertEquals(TEST_USER_ID, result.getCdUserId());
+        assertEquals(TEST_USER_ID, result.getUserId());
+        assertEquals(TEST_TENANT_ID, result.getTenantId());
+        assertEquals(TEST_ACCESS_KEY, result.getAccessKey());
+        assertEquals(NOT_AVAILABLE, result.getSecretKey());
+        assertTrue(result.getActive());
+        assertNotNull(result.getCreationDate());
+    }
+
+    @Test
     public void testToIAMListUsersRequest() {
         // Setup
         // Run the test
@@ -566,7 +611,7 @@ public class ScalityModelConverterTest {
         assertEquals(TEST_USER_ID , resultWithNoSecret.getUserId());
         assertEquals(SAMPLE_TENANT_ID, resultWithNoSecret.getTenantId());
         assertEquals(TEST_ACCESS_KEY_2, resultWithNoSecret.getAccessKey());
-        assertEquals(ScalityConstants.NOT_AVAILABLE, resultWithNoSecret.getSecretKey());
+        assertEquals(NOT_AVAILABLE, resultWithNoSecret.getSecretKey());
 
     }
 


### PR DESCRIPTION
Description:
* Re-structuring REST Controller to modify the implementation logic with same API signatures
*  Update design for `getS3Credentials`
* Implement `getS3Credentials`
  * Logic:
      * Call `list-access-keys` with provided tenantId, userID
      * Filter the `access-key` with provided accesskey value
      * Extract the secret key for the given accesskey from REDIS and decrypt it
      * If no secret key present in REDIS, return "Not Available" string for secret key
* Implement `getS3Credentials` test cases

**_Note to reviewer:_**
* _As per the Vmware’s [documentation](https://code.vmware.com/apis/1034#/required/getCredential), `tenantID` and `userID` will always present in the request and it is the platform implementation choice to use them or not._
* _As the original code has copyright and two `REST Controllers` with same API signature cannot be used, old REST Controller with name `com.vmware.osis.OsisController.java` has been removed from the project and reused same code to develop `com.scality.osis.ScalityOsisController.java`_